### PR TITLE
Enable the specified precomputed chunk linkage.

### DIFF
--- a/src/marsilea/_deform.py
+++ b/src/marsilea/_deform.py
@@ -84,19 +84,21 @@ class Deformation:
         self.data_col_reindex = reindex
         self._col_clustered = False
 
-    def set_cluster(self, col=None, row=None, use_meta=True, linkage=None, **kwargs):
+    def set_cluster(self, col=None, row=None, use_meta=True, linkage=None, meta_linkage=None, **kwargs):
         if col is not None:
             self.is_col_cluster = col
             self.col_cluster_kws = kwargs
             self._col_clustered = False
             self._use_col_meta = use_meta
             self.col_linkage = linkage
+            self.col_meta_linkage = meta_linkage
         if row is not None:
             self.is_row_cluster = row
             self.row_cluster_kws = kwargs
             self._row_clustered = False
             self._use_row_meta = use_meta
             self.row_linkage = linkage
+            self.row_meta_linkage = meta_linkage
 
     def get_data(self):
         data = self.data
@@ -204,7 +206,7 @@ class Deformation:
                     Dendrogram(chunk, linkage=linkage, key=k, **self.row_cluster_kws)
                 )
 
-            dg = GroupDendrogram(dens, **self.row_cluster_kws)
+            dg = GroupDendrogram(dens, linkage=self.row_meta_linkage, **self.row_cluster_kws)
             if self._use_row_meta:
                 self.row_chunk_index = dg.reorder_index
             else:
@@ -232,7 +234,7 @@ class Deformation:
                 dens.append(
                     Dendrogram(chunk.T, linkage=linkage, key=k, **self.col_cluster_kws)
                 )
-            dg = GroupDendrogram(dens, **self.col_cluster_kws)
+            dg = GroupDendrogram(dens, linkage=self.col_meta_linkage,  **self.col_cluster_kws)
             if self._use_col_meta:
                 self.col_chunk_index = dg.reorder_index
             else:

--- a/src/marsilea/base.py
+++ b/src/marsilea/base.py
@@ -835,6 +835,7 @@ class ClusterBoard(WhiteBoard):
         method=None,
         metric=None,
         linkage=None,
+        meta_linkage=None,
         add_meta=True,
         add_base=True,
         add_divider=True,
@@ -867,6 +868,10 @@ class ClusterBoard(WhiteBoard):
             See scipy's :meth:`linkage <scipy.cluster.hierarchy.linkage>`
         linkage : ndarray
             Precomputed linkage matrix.
+            See scipy's :meth:`linkage <scipy.cluster.hierarchy.linkage>` for
+            specific format.
+        meta_linkage : ndarray
+            Precomputed chunk-level linkage matrix.
             See scipy's :meth:`linkage <scipy.cluster.hierarchy.linkage>` for
             specific format.
         add_meta : None | bool
@@ -985,6 +990,7 @@ class ClusterBoard(WhiteBoard):
                 method=method,
                 metric=metric,
                 linkage=linkage,
+                meta_linkage=meta_linkage, 
                 use_meta=add_meta,
                 get_meta_center=get_meta_center,
             )
@@ -996,6 +1002,7 @@ class ClusterBoard(WhiteBoard):
                 method=method,
                 metric=metric,
                 linkage=linkage,
+                meta_linkage=meta_linkage, 
                 use_meta=add_meta,
                 get_meta_center=get_meta_center,
             )

--- a/src/marsilea/dendrogram.py
+++ b/src/marsilea/dendrogram.py
@@ -267,13 +267,14 @@ class GroupDendrogram(_DendrogramBase):
         dens: List[Dendrogram],
         method=None,
         metric=None,
+        linkage=None,
         get_meta_center=None,
         key=None,
         **kwargs,
     ):
         data = np.vstack([d.center for d in dens])
         super().__init__(
-            data, method=method, metric=metric, get_meta_center=get_meta_center, key=key
+            data, method=method, metric=metric, linkage=linkage, get_meta_center=get_meta_center, key=key
         )
         self.orig_dens = np.asarray(dens)
         self.dens = np.asarray(dens)[self.reorder_index]


### PR DESCRIPTION
Use case: When analyzing single-cell data, we may sometimes need to calculate the cluster linkage based on the PC results and then use that linkage for other analyses, such as identifying spec genes.


```

h.add_dendrogram(
    'top', add_base=False, meta_linkage=adata.uns['dendrogram_Cluster']['linkage']
)
```