### PR TITLE
Fix parsing NA value of text annot in ColorMesh

### DIFF
--- a/src/marsilea/plotter/_utils.py
+++ b/src/marsilea/plotter/_utils.py
@@ -10,12 +10,12 @@ def _format_labels(labels, fmt):
 
 
 def _format_label(a, fmt):
-    if np.isnan(a):
-        a = ""
     if isinstance(fmt, str):
         label = _auto_format_str(fmt, a)
     elif callable(fmt):
         label = fmt(a)
+    elif np.isnan(a):
+        a = ""
     else:
         raise TypeError("fmt must be a str or callable")
     return label


### PR DESCRIPTION
When pass text for heatmap annot, error with `TypeError: ufunc 'isnan' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''`