### PR TITLE
fix: repair Read the Docs build broken by legendkit 0.4.1

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -4,5 +4,5 @@ source/how_to/
 source/tutorial/*.png
 source/api/APIs
 sg_execution_times.rst
-how_to/*.png
-how_to/*.pdf
+how_to/**/*.png
+how_to/**/*.pdf

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -9,8 +9,11 @@ build:
     # RTD checks out a shallow clone with no tags, so uv-dynamic-versioning
     # cannot derive the version and falls back to 0.0.0. Fetch the tags so the
     # docs report the real release.
+    # Both are kept non-fatal: --unshallow errors on an already-complete
+    # checkout, and a missing tag only costs an accurate version, not the build.
     post_checkout:
-      - git fetch --unshallow --tags || true
+      - git fetch --unshallow || true
+      - git fetch --tags || true
     post_install:
       - pip install uv
       - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --link-mode=copy

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -6,6 +6,11 @@ build:
   tools:
     python: "3.12"
   jobs:
+    # RTD checks out a shallow clone with no tags, so uv-dynamic-versioning
+    # cannot derive the version and falls back to 0.0.0. Fetch the tags so the
+    # docs report the real release.
+    post_checkout:
+      - git fetch --unshallow --tags || true
     post_install:
       - pip install uv
       - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --link-mode=copy

--- a/src/marsilea/plotter/bar.py
+++ b/src/marsilea/plotter/bar.py
@@ -402,7 +402,9 @@ class StackBar(_BarBase):
     def get_legends(self):
         if self.labels is not None:
             return CatLegend(
-                colors=self.bar_colors, labels=self.labels, **self._legend_kws
+                colors=self.bar_colors[: len(self.labels)],
+                labels=self.labels,
+                **self._legend_kws,
             )
 
     def render_ax(self, spec):

--- a/tests/test_plotters_smoke.py
+++ b/tests/test_plotters_smoke.py
@@ -56,6 +56,16 @@ def test_stackbar(data_2d, rng):
     h.render()
 
 
+def test_stackbar_legend_default_palette(data_2d, rng):
+    # The default palette is 16 colors regardless of item count; the legend must
+    # trim it to the labels or legendkit rejects the length mismatch.
+    stack_data = pd.DataFrame(rng.random((3, 6)), index=["cat_a", "cat_b", "cat_c"])
+    h = ma.Heatmap(data_2d)
+    h.add_top(mp.StackBar(stack_data))
+    h.add_legends()
+    h.render()
+
+
 # --- CenterBar ---
 
 


### PR DESCRIPTION
## Problem

The Read the Docs build fails. `docs/examples/Basics/plot_stacked_bar.py` cannot execute, so sphinx exits 2:

```
ValueError: colors and labels must have the same length, got 16 colors and 5 labels
  File "src/marsilea/plotter/bar.py", line 404, in get_legends
  File "legendkit/_legend.py", line 469, in __init__
```

This is a library bug, not a docs bug. `StackBar` falls back to the 16-color `ECHARTS16` palette regardless of item count. `render_ax` already trimmed the palette to the data (`self.bar_colors[: len(data)]`), but `get_legends` passed all 16 colors alongside the real labels. The mismatch was harmless until legendkit 0.4.1 added length validation, which this repo picked up in #91.

Any `StackBar` with a legend and fewer than 16 items is affected, not just the docs.

## Changes

- `src/marsilea/plotter/bar.py` — trim the legend colors to the labels, matching what `render_ax` already does.
- `tests/test_plotters_smoke.py` — the existing `test_stackbar` never called `add_legends()`, so it could not catch this. Added a case that does.
- `readthedocs.yaml` — RTD checks out a shallow clone with no tags, so `uv-dynamic-versioning` could not derive a version and fell back to `0.0.0`. Since `conf.py` sets `release = ma.__version__`, the published docs advertised `0.0.0.post1.dev0`. Fetch tags in `post_checkout`.
- `docs/.gitignore` — `how_to/*.png` and `how_to/*.pdf` miss the artifacts sphinx-gallery writes one level deeper (`how_to/save/plot.png`). Widened to `how_to/**/*`.

## Verification

- Clean `sphinx-build` from scratch (`docs/clean_up.py` first): exit 2 before, **exit 0 with zero warnings** after.
- `pytest tests/test_plotters_smoke.py`: 20 passed.
- Version fallback reproduced on a `git clone --depth 1 --no-tags` checkout: `0.0.0.post1.dev0` before the `post_checkout` fetch, `0.6.2.post4.dev0` after.
- Audited the other four `CatLegend` call sites. `_seaborn.py` builds its palette with `dict(zip(hue, colors))` and `mesh.py` uses `cycle()` with `enumerate`, so both self-truncate. `bar.py` was the only one affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
