### PR TITLE
Fix dendrogram crashes, simplify Deformation, and let group heights be compared

### DIFF
--- a/docs/how_to/dendrogram/plot_dendrogram_height.py
+++ b/docs/how_to/dendrogram/plot_dendrogram_height.py
@@ -1,0 +1,75 @@
+"""
+Balancing dendrogram heights
+============================
+
+When groups cluster at very different tightness, the default scaling can make
+the dendrogram look lopsided. This example shows the two knobs that fix it.
+
+"""
+
+# %%
+import numpy as np
+import marsilea as ma
+
+# Three groups with deliberately different spread: the first is tight, the
+# second is diffuse, the third sits in between.
+rng = np.random.default_rng(0)
+data = np.vstack(
+    [
+        rng.standard_normal((10, 8)) * 0.05,
+        rng.standard_normal((25, 8)) * 3.0,
+        rng.standard_normal((15, 8)),
+    ]
+)
+groups = ["tight"] * 10 + ["diffuse"] * 25 + ["middle"] * 15
+order = ["tight", "diffuse", "middle"]
+
+
+# %%
+# The default, ``height_scale="minmax"``, stretches each group over the full
+# height. Every group reaches the same apex whatever its rows actually do, so
+# the tight group looks as deep as the diffuse one and the meta dendrogram
+# sits on a flat plateau.
+
+h = ma.Heatmap(data, width=3, height=3)
+h.group_rows(groups, order=order)
+h.add_dendrogram("left", method="ward")
+h.render()
+
+# %%
+# ``height_scale="shared"`` measures every group against the tallest merge
+# anywhere, so the drawn heights are in proportion to the real distances. The
+# tight group now draws short, and the length of each root line says how far
+# that group had left to travel before joining the others.
+
+h = ma.Heatmap(data, width=3, height=3)
+h.group_rows(groups, order=order)
+h.add_dendrogram("left", method="ward", height_scale="shared")
+h.render()
+
+# %%
+# Honest heights can be hard to read when one group is very tight. Merges also
+# tend to bunch up near the leaves, badly so with ``method="ward"``, leaving
+# the top of the plot empty. ``height_transform`` opens up the low end without
+# ever reordering two merges.
+#
+# ``"sqrt"`` is the gentlest, ``"log"`` stronger, and ``"rank"`` spreads the
+# merges out evenly. They buy legibility by giving up readable distances, so
+# reach for them when the shape of the tree matters more than its scale.
+
+h = ma.Heatmap(data, width=3, height=3)
+h.group_rows(groups, order=order)
+h.add_dendrogram("left", method="ward", height_scale="shared", height_transform="sqrt")
+h.render()
+
+# %%
+# With any scale other than the default, ``meta_ratio`` is exact: the meta
+# dendrogram is drawn at that fraction of the base dendrogram's height, and
+# its leaves sit directly on the divider.
+
+h = ma.Heatmap(data, width=3, height=3)
+h.group_rows(groups, order=order)
+h.add_dendrogram(
+    "left", method="ward", height_scale="shared", meta_ratio=0.4, meta_color="#7EA1FF"
+)
+h.render()

--- a/src/marsilea/_deform.py
+++ b/src/marsilea/_deform.py
@@ -103,25 +103,23 @@ class Deformation:
         self._col_clustered = False
         self._row_clustered = False
 
-    def set_data_row_reindex(self, reindex):
-        if len(reindex) != self._nrow:
+    def _set_reindex(self, axis, reindex):
+        state = self._axes[axis]
+        if len(reindex) != state.n:
             msg = (
                 f"Length of reindex ({len(reindex)}) should match "
-                f"data row with {self._nrow} elements"
+                f"data {'row' if axis == _ROW else 'col'} with "
+                f"{state.n} elements"
             )
             raise ValueError(msg)
-        self.data_row_reindex = reindex
-        self._row_clustered = False
+        state.reindex = reindex
+        state.clustered = False
+
+    def set_data_row_reindex(self, reindex):
+        self._set_reindex(_ROW, reindex)
 
     def set_data_col_reindex(self, reindex):
-        if len(reindex) != self._ncol:
-            msg = (
-                f"Length of reindex ({len(reindex)}) should match "
-                f"data col with {self._ncol} elements"
-            )
-            raise ValueError(msg)
-        self.data_col_reindex = reindex
-        self._col_clustered = False
+        self._set_reindex(_COL, reindex)
 
     def set_cluster(
         self,
@@ -132,22 +130,17 @@ class Deformation:
         meta_linkage=None,
         **kwargs,
     ):
-        if col is not None:
-            self.is_col_cluster = col
-            self.col_cluster_kws = kwargs
-            self._col_clustered = False
-            self._col_ratios_cache = None
-            self._use_col_meta = use_meta
-            self.col_linkage = linkage
-            self.col_meta_linkage = meta_linkage
-        if row is not None:
-            self.is_row_cluster = row
-            self.row_cluster_kws = kwargs
-            self._row_clustered = False
-            self._row_ratios_cache = None
-            self._use_row_meta = use_meta
-            self.row_linkage = linkage
-            self.row_meta_linkage = meta_linkage
+        for axis, cluster in ((_COL, col), (_ROW, row)):
+            if cluster is None:
+                continue
+            state = self._axes[axis]
+            state.is_cluster = cluster
+            state.cluster_kws = kwargs
+            state.clustered = False
+            state.ratios_cache = None
+            state.use_meta = use_meta
+            state.linkage = linkage
+            state.meta_linkage = meta_linkage
 
     def get_data(self):
         data = self.data
@@ -157,57 +150,54 @@ class Deformation:
             data = data[:, self.data_col_reindex]
         return data
 
+    def _set_split(self, axis, breakpoints=None, order=None):
+        if breakpoints is None:
+            return
+        state = self._axes[axis]
+        state.is_split = True
+        state.breakpoints = [0, *np.sort(np.asarray(breakpoints)), state.n]
+        if order is None:
+            order = np.arange(len(breakpoints) + 1)
+        state.split_order = order
+        state.ratios_cache = None
+
     def set_split_row(self, breakpoints=None, order=None):
-        if breakpoints is not None:
-            self.is_row_split = True
-            self.row_breakpoints = [0, *np.sort(np.asarray(breakpoints)), self._nrow]
-            if order is None:
-                order = np.arange(len(breakpoints) + 1)
-            self.row_split_order = order
-            self._row_ratios_cache = None
+        self._set_split(_ROW, breakpoints, order)
 
     def set_split_col(self, breakpoints=None, order=None):
-        if breakpoints is not None:
-            self.is_col_split = True
-            self.col_breakpoints = [0, *np.sort(np.asarray(breakpoints)), self._ncol]
-            if order is None:
-                order = np.arange(len(breakpoints) + 1)
-            self.col_split_order = order
-            self._col_ratios_cache = None
+        self._set_split(_COL, breakpoints, order)
+
+    def _ratios(self, axis):
+        state = self._axes[axis]
+        if state.ratios_cache is not None:
+            return state.ratios_cache
+        self._run_cluster()
+        if state.breakpoints is None:
+            return None
+        ratios = np.array([ix2 - ix1 for ix1, ix2 in pairwise(state.breakpoints)])
+        if state.chunk_index is not None:
+            ratios = ratios[state.chunk_index]
+        state.ratios_cache = ratios
+        return ratios
 
     @property
     def row_ratios(self):
-        if self._row_ratios_cache is not None:
-            return self._row_ratios_cache
-        self._run_cluster()
-        if self.row_breakpoints is None:
-            return None
-        ratios = np.array([ix2 - ix1 for ix1, ix2 in pairwise(self.row_breakpoints)])
-        if self.row_chunk_index is not None:
-            ratios = ratios[self.row_chunk_index]
-        self._row_ratios_cache = ratios
-        return ratios
+        return self._ratios(_ROW)
 
     @property
     def col_ratios(self):
-        if self._col_ratios_cache is not None:
-            return self._col_ratios_cache
-        self._run_cluster()
-        if self.col_breakpoints is None:
-            return None
-        ratios = np.array([ix2 - ix1 for ix1, ix2 in pairwise(self.col_breakpoints)])
-        if self.col_chunk_index is not None:
-            ratios = ratios[self.col_chunk_index]
-        self._col_ratios_cache = ratios
-        return ratios
+        return self._ratios(_COL)
+
+    def _set_chunk_order(self, axis, order):
+        state = self._axes[axis]
+        state.chunk_index = order
+        state.ratios_cache = None
 
     def set_row_chunk_order(self, order):
-        self.row_chunk_index = order
-        self._row_ratios_cache = None
+        self._set_chunk_order(_ROW, order)
 
     def set_col_chunk_order(self, order):
-        self.col_chunk_index = order
-        self._col_ratios_cache = None
+        self._set_chunk_order(_COL, order)
 
     def split_by_row(self, data: np.ndarray):
         if not self.is_row_split:
@@ -243,68 +233,56 @@ class Deformation:
         "with keys as group names and values as linkage"
     )
 
-    def cluster_row(self):
-        row_data = self.split_by_row(self.get_data())
-        if self.is_row_split:
-            if not (
-                isinstance(self.row_linkage, Mapping) or (self.row_linkage is None)
-            ):
+    def _cluster(self, axis):
+        """Cluster one axis, chunk by chunk when it is split.
+
+        Columns are clustered as observations, so each chunk is transposed
+        before it reaches the dendrogram.
+        """
+        state = self._axes[axis]
+        splitter = self.split_by_row if axis == _ROW else self.split_by_col
+        data = splitter(self.get_data())
+        # rows are already observations; columns become observations transposed
+        observations = (
+            (lambda chunk: chunk) if axis == _ROW else (lambda chunk: chunk.T)
+        )
+
+        if state.is_split:
+            if not (isinstance(state.linkage, Mapping) or (state.linkage is None)):
                 raise TypeError(self._linkage_check_msg)
             dens = []
-            for chunk, k in zip(row_data, self.row_split_order):
+            for chunk, k in zip(data, state.split_order):
                 linkage = None
-                if self.row_linkage is not None:
-                    linkage = self.row_linkage.get(k)
+                if state.linkage is not None:
+                    linkage = state.linkage.get(k)
                     if linkage is None:
                         raise KeyError(f"Linkage for group {k} is not specified")
                 dens.append(
-                    Dendrogram(chunk, linkage=linkage, key=k, **self.row_cluster_kws)
+                    Dendrogram(
+                        observations(chunk),
+                        linkage=linkage,
+                        key=k,
+                        **state.cluster_kws,
+                    )
                 )
-
-            dg = GroupDendrogram(
-                dens, linkage=self.row_meta_linkage, **self.row_cluster_kws
-            )
-            if self._use_row_meta:
-                self.row_chunk_index = dg.reorder_index
+            dg = GroupDendrogram(dens, linkage=state.meta_linkage, **state.cluster_kws)
+            if state.use_meta:
+                state.chunk_index = dg.reorder_index
             else:
-                self.row_chunk_index = np.arange(len(dens))
-            self.row_reorder_index = [d.reorder_index for d in dens]
-        else:
-            dg = Dendrogram(row_data, linkage=self.row_linkage, **self.row_cluster_kws)
-            self.row_reorder_index = dg.reorder_index
-        self.row_dendrogram = dg
-
-    def cluster_col(self):
-        col_data = self.split_by_col(self.get_data())
-        if self.is_col_split:
-            if not (
-                isinstance(self.col_linkage, Mapping) or (self.col_linkage is None)
-            ):
-                raise TypeError(self._linkage_check_msg)
-            dens = []
-            for chunk, k in zip(col_data, self.col_split_order):
-                linkage = None
-                if self.col_linkage is not None:
-                    linkage = self.col_linkage.get(k)
-                    if linkage is None:
-                        raise KeyError(f"Linkage for group {k} is not specified")
-                dens.append(
-                    Dendrogram(chunk.T, linkage=linkage, key=k, **self.col_cluster_kws)
-                )
-            dg = GroupDendrogram(
-                dens, linkage=self.col_meta_linkage, **self.col_cluster_kws
-            )
-            if self._use_col_meta:
-                self.col_chunk_index = dg.reorder_index
-            else:
-                self.col_chunk_index = np.arange(len(dens))
-            self.col_reorder_index = [d.reorder_index for d in dens]
+                state.chunk_index = np.arange(len(dens))
+            state.reorder_index = [d.reorder_index for d in dens]
         else:
             dg = Dendrogram(
-                col_data.T, linkage=self.col_linkage, **self.col_cluster_kws
+                observations(data), linkage=state.linkage, **state.cluster_kws
             )
-            self.col_reorder_index = dg.reorder_index
-        self.col_dendrogram = dg
+            state.reorder_index = dg.reorder_index
+        state.dendrogram = dg
+
+    def cluster_row(self):
+        self._cluster(_ROW)
+
+    def cluster_col(self):
+        self._cluster(_COL)
 
     def _run_cluster(self):
         """Calculation of dendrogram is expensive,
@@ -434,28 +412,31 @@ class Deformation:
         trans_data = self.reorder_by_col(trans_data, split="1d")
         return trans_data
 
-    def get_row_dendrogram(self):
+    def _get_dendrogram(self, axis):
         # Update the cluster result
         self._run_cluster()
-        return self.row_dendrogram
+        return self._axes[axis].dendrogram
+
+    def get_row_dendrogram(self):
+        return self._get_dendrogram(_ROW)
 
     def get_col_dendrogram(self):
-        self._run_cluster()
-        return self.col_dendrogram
+        return self._get_dendrogram(_COL)
+
+    def _get_linkage(self, axis):
+        state = self._axes[axis]
+        if state.dendrogram is None:
+            return None
+        if state.is_split:
+            # a single-element chunk has no linkage, its Z is None
+            return {x.key: x.Z for x in state.dendrogram.orig_dens}
+        return state.dendrogram.Z
 
     def get_row_linkage(self):
-        if self.row_dendrogram is not None:
-            if self.is_row_split:
-                return {x.key: x.Z for x in self.row_dendrogram.orig_dens}
-            else:
-                return self.row_dendrogram.Z
+        return self._get_linkage(_ROW)
 
     def get_col_linkage(self):
-        if self.col_dendrogram is not None:
-            if self.is_col_split:
-                return {x.key: x.Z for x in self.col_dendrogram.orig_dens}
-            else:
-                return self.col_dendrogram.Z
+        return self._get_linkage(_COL)
 
     @property
     def is_split(self):

--- a/src/marsilea/_deform.py
+++ b/src/marsilea/_deform.py
@@ -1,11 +1,77 @@
-from typing import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Mapping
 
 import numpy as np
 
 from .dendrogram import Dendrogram, GroupDendrogram
 from .utils import pairwise
 
+_ROW, _COL = 0, 1
 
+
+@dataclass
+class _AxisState:
+    """Everything Deformation tracks about one axis."""
+
+    n: int
+    is_split: bool = False
+    is_cluster: bool = False
+    clustered: bool = False
+    reindex: Any = None
+    breakpoints: Any = None
+    split_order: Any = None
+    dendrogram: Any = None
+    linkage: Any = None  # User supplied linkage
+    meta_linkage: Any = None
+    use_meta: bool = True
+    reorder_index: Any = None
+    chunk_index: Any = None
+    cluster_kws: dict = field(default_factory=dict)
+    ratios_cache: Any = None
+
+
+class _AxisAttr:
+    """Forward ``Deformation.<row|col>_<name>`` to its per-axis state."""
+
+    __slots__ = ("axis", "field")
+
+    def __init__(self, axis, field):
+        self.axis = axis
+        self.field = field
+
+    def __get__(self, obj, owner=None):
+        if obj is None:
+            return self
+        return getattr(obj._axes[self.axis], self.field)
+
+    def __set__(self, obj, value):
+        setattr(obj._axes[self.axis], self.field, value)
+
+
+def _forward_axis_attrs(cls):
+    """Keep the public row_*/col_* names while the state lives per axis."""
+    for template, attr in [
+        ("is_{}_split", "is_split"),
+        ("is_{}_cluster", "is_cluster"),
+        ("_{}_clustered", "clustered"),
+        ("data_{}_reindex", "reindex"),
+        ("{}_breakpoints", "breakpoints"),
+        ("{}_split_order", "split_order"),
+        ("{}_dendrogram", "dendrogram"),
+        ("{}_linkage", "linkage"),
+        ("{}_meta_linkage", "meta_linkage"),
+        ("_use_{}_meta", "use_meta"),
+        ("{}_reorder_index", "reorder_index"),
+        ("{}_chunk_index", "chunk_index"),
+        ("{}_cluster_kws", "cluster_kws"),
+        ("_{}_ratios_cache", "ratios_cache"),
+    ]:
+        setattr(cls, template.format("row"), _AxisAttr(_ROW, attr))
+        setattr(cls, template.format("col"), _AxisAttr(_COL, attr))
+    return cls
+
+
+@_forward_axis_attrs
 class Deformation:
     """A helper class to handle data
 
@@ -16,51 +82,24 @@ class Deformation:
 
     """
 
-    is_row_split = False
-    is_col_split = False
-    is_row_cluster = False
-    is_col_cluster = False
-    _row_clustered = False
-    _col_clustered = False
-
-    data_row_reindex = None
-    data_col_reindex = None
-
-    row_breakpoints = None
-    col_breakpoints = None
-    row_split_order = None
-    col_split_order = None
-
-    row_dendrogram = None
-    col_dendrogram = None
-    row_linkage = None  # User supplied linkage
-    col_linkage = None
-
-    row_reorder_index = None
-    col_reorder_index = None
-
-    row_chunk_index = None
-    col_chunk_index = None
-    _use_col_meta = True
-    _use_row_meta = True
-
-    # just for storage
-    wspace = 0
-    hspace = 0
-
-    row_cluster_kws = {}
-    col_cluster_kws = {}
-
-    data = None
-    _nrow = None
-    _ncol = None
-
     def __init__(self, data):
+        self._axes = (_AxisState(0), _AxisState(0))
+        # just for storage
+        self.wspace = 0
+        self.hspace = 0
         self.set_data(data)
+
+    @property
+    def _nrow(self):
+        return self._axes[_ROW].n
+
+    @property
+    def _ncol(self):
+        return self._axes[_COL].n
 
     def set_data(self, data):
         self.data = data
-        self._nrow, self._ncol = data.shape
+        self._axes[_ROW].n, self._axes[_COL].n = data.shape
         self._col_clustered = False
         self._row_clustered = False
 
@@ -135,9 +174,6 @@ class Deformation:
                 order = np.arange(len(breakpoints) + 1)
             self.col_split_order = order
             self._col_ratios_cache = None
-
-    _row_ratios_cache = None
-    _col_ratios_cache = None
 
     @property
     def row_ratios(self):

--- a/src/marsilea/_deform.py
+++ b/src/marsilea/_deform.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import dataclass, field
 from typing import Any, Mapping
 
@@ -7,6 +8,18 @@ from .dendrogram import Dendrogram, GroupDendrogram
 from .utils import pairwise
 
 _ROW, _COL = 0, 1
+
+
+@dataclass(frozen=True)
+class _Plan:
+    """One axis resolved into where every element ends up.
+
+    ``index`` is a flat permutation of the axis and ``bounds`` marks the chunk
+    boundaries within it, so deforming anything is a take followed by slices.
+    """
+
+    index: np.ndarray
+    bounds: np.ndarray
 
 
 @dataclass
@@ -27,7 +40,11 @@ class _AxisState:
     reorder_index: Any = None
     chunk_index: Any = None
     cluster_kws: dict = field(default_factory=dict)
-    ratios_cache: Any = None
+    plan: Any = None
+
+    def invalidate(self):
+        self.clustered = False
+        self.plan = None
 
 
 class _AxisAttr:
@@ -64,7 +81,6 @@ def _forward_axis_attrs(cls):
         ("{}_reorder_index", "reorder_index"),
         ("{}_chunk_index", "chunk_index"),
         ("{}_cluster_kws", "cluster_kws"),
-        ("_{}_ratios_cache", "ratios_cache"),
     ]:
         setattr(cls, template.format("row"), _AxisAttr(_ROW, attr))
         setattr(cls, template.format("col"), _AxisAttr(_COL, attr))
@@ -100,8 +116,8 @@ class Deformation:
     def set_data(self, data):
         self.data = data
         self._axes[_ROW].n, self._axes[_COL].n = data.shape
-        self._col_clustered = False
-        self._row_clustered = False
+        for state in self._axes:
+            state.invalidate()
 
     def _set_reindex(self, axis, reindex):
         state = self._axes[axis]
@@ -113,7 +129,7 @@ class Deformation:
             )
             raise ValueError(msg)
         state.reindex = reindex
-        state.clustered = False
+        state.invalidate()
 
     def set_data_row_reindex(self, reindex):
         self._set_reindex(_ROW, reindex)
@@ -136,11 +152,10 @@ class Deformation:
             state = self._axes[axis]
             state.is_cluster = cluster
             state.cluster_kws = kwargs
-            state.clustered = False
-            state.ratios_cache = None
             state.use_meta = use_meta
             state.linkage = linkage
             state.meta_linkage = meta_linkage
+            state.invalidate()
 
     def get_data(self):
         data = self.data
@@ -159,7 +174,7 @@ class Deformation:
         if order is None:
             order = np.arange(len(breakpoints) + 1)
         state.split_order = order
-        state.ratios_cache = None
+        state.plan = None
 
     def set_split_row(self, breakpoints=None, order=None):
         self._set_split(_ROW, breakpoints, order)
@@ -168,17 +183,11 @@ class Deformation:
         self._set_split(_COL, breakpoints, order)
 
     def _ratios(self, axis):
-        state = self._axes[axis]
-        if state.ratios_cache is not None:
-            return state.ratios_cache
-        self._run_cluster()
-        if state.breakpoints is None:
+        """Chunk sizes, in drawing order, for splitting the axes."""
+        if self._axes[axis].breakpoints is None:
+            self._run_cluster()
             return None
-        ratios = np.array([ix2 - ix1 for ix1, ix2 in pairwise(state.breakpoints)])
-        if state.chunk_index is not None:
-            ratios = ratios[state.chunk_index]
-        state.ratios_cache = ratios
-        return ratios
+        return np.diff(self._get_plan(axis).bounds)
 
     @property
     def row_ratios(self):
@@ -191,7 +200,7 @@ class Deformation:
     def _set_chunk_order(self, axis, order):
         state = self._axes[axis]
         state.chunk_index = order
-        state.ratios_cache = None
+        state.plan = None
 
     def set_row_chunk_order(self, order):
         self._set_chunk_order(_ROW, order)
@@ -199,33 +208,15 @@ class Deformation:
     def set_col_chunk_order(self, order):
         self._set_chunk_order(_COL, order)
 
-    def split_by_row(self, data: np.ndarray):
-        if not self.is_row_split:
+    def _split_chunks(self, axis, data):
+        """Cut data at the breakpoints, still in the original order."""
+        state = self._axes[axis]
+        if not state.is_split:
             return data
-        return [data[ix1:ix2] for ix1, ix2 in pairwise(self.row_breakpoints)]
-
-    def split_by_col(self, data: np.ndarray):
-        if not self.is_col_split:
-            return data
-        if data.ndim == 1:
-            return [data[ix1:ix2] for ix1, ix2 in pairwise(self.col_breakpoints)]
-        else:
-            return [data[:, ix1:ix2] for ix1, ix2 in pairwise(self.col_breakpoints)]
-
-    def split_cross(self, data: np.ndarray):
-        if self.is_col_split & self.is_row_split:
-            split_data = []
-            for ix1, ix2 in pairwise(self.row_breakpoints):
-                row = []
-                for iy1, iy2 in pairwise(self.col_breakpoints):
-                    row.append(data[ix1:ix2, iy1:iy2])
-                split_data.append(row)
-            return split_data
-        if self.is_row_split:
-            return self.split_by_row(data)
-        if self.is_col_split:
-            return self.split_by_col(data)
-        return data
+        if axis == _ROW:
+            return [data[ix1:ix2] for ix1, ix2 in pairwise(state.breakpoints)]
+        # ... keeps this working for 1d column data too
+        return [data[..., ix1:ix2] for ix1, ix2 in pairwise(state.breakpoints)]
 
     _linkage_check_msg = (
         "If you want to specific linkage when splitting, "
@@ -240,8 +231,7 @@ class Deformation:
         before it reaches the dendrogram.
         """
         state = self._axes[axis]
-        splitter = self.split_by_row if axis == _ROW else self.split_by_col
-        data = splitter(self.get_data())
+        data = self._split_chunks(axis, self.get_data())
         # rows are already observations; columns become observations transposed
         observations = (
             (lambda chunk: chunk) if axis == _ROW else (lambda chunk: chunk.T)
@@ -294,9 +284,153 @@ class Deformation:
             self.cluster_col()
             self._col_clustered = True
 
-    def reorder_by_row(self, data, split="2d"):
+    def _get_plan(self, axis) -> _Plan:
+        """Resolve one axis into where every element ends up.
+
+        Grouping, splitting, the leaf order within each chunk and the order of
+        the chunks themselves all compose into a single permutation. This is
+        the only place that decides layout.
+        """
+        state = self._axes[axis]
+        if state.plan is not None:
+            return state.plan
         self._run_cluster()
-        # no cluster, return immediately
+
+        index = (
+            np.arange(state.n) if state.reindex is None else np.asarray(state.reindex)
+        )
+        if not state.is_split:
+            if state.is_cluster:
+                index = index[state.reorder_index]
+            state.plan = _Plan(index, np.array([0, state.n]))
+            return state.plan
+
+        chunks = [index[ix1:ix2] for ix1, ix2 in pairwise(state.breakpoints)]
+        if state.is_cluster:
+            chunks = [c[np.asarray(o)] for c, o in zip(chunks, state.reorder_index)]
+        if state.chunk_index is not None:
+            chunks = [chunks[ix] for ix in state.chunk_index]
+        state.plan = _Plan(
+            np.concatenate(chunks),
+            np.concatenate([[0], np.cumsum([len(c) for c in chunks])]),
+        )
+        return state.plan
+
+    def _apply(self, axis, data):
+        """Deform data whose last axis indexes this one."""
+        state = self._axes[axis]
+        if data.shape[-1] != state.n:
+            msg = (
+                f"Data has {data.shape[-1]} elements on the "
+                f"{'row' if axis == _ROW else 'column'} axis, "
+                f"expected {state.n}"
+            )
+            raise ValueError(msg)
+        plan = self._get_plan(axis)
+        deformed = np.take(data, plan.index, axis=-1)
+        if not state.is_split:
+            return deformed
+        return [deformed[..., ix1:ix2] for ix1, ix2 in pairwise(plan.bounds)]
+
+    def transform(self, data: np.ndarray):
+        """data must be 2d array with the same shape as cluster data"""
+        if not data.shape == (self._nrow, self._ncol):
+            msg = (
+                f"The shape of input data {data.shape} does not align with"
+                f" the shape of cluster data {(self._nrow, self._ncol)}"
+            )
+            raise ValueError(msg)
+        rows, cols = self._get_plan(_ROW), self._get_plan(_COL)
+        deformed = data[np.ix_(rows.index, cols.index)]
+        if not self.is_split:
+            return deformed
+        # a 2d split is handed back flattened, one row of blocks at a time
+        return [
+            deformed[ix1:ix2, iy1:iy2]
+            for ix1, ix2 in pairwise(rows.bounds)
+            for iy1, iy2 in pairwise(cols.bounds)
+        ]
+
+    def transform_row(self, data: np.ndarray):
+        """Deform data whose last axis indexes rows."""
+        return self._apply(_ROW, data)
+
+    def transform_col(self, data: np.ndarray):
+        """Deform data whose last axis indexes columns."""
+        return self._apply(_COL, data)
+
+    def _get_dendrogram(self, axis):
+        # Update the cluster result
+        self._run_cluster()
+        return self._axes[axis].dendrogram
+
+    def get_row_dendrogram(self):
+        return self._get_dendrogram(_ROW)
+
+    def get_col_dendrogram(self):
+        return self._get_dendrogram(_COL)
+
+    def _get_linkage(self, axis):
+        state = self._axes[axis]
+        if state.dendrogram is None:
+            return None
+        if state.is_split:
+            # a single-element chunk has no linkage, its Z is None
+            return {x.key: x.Z for x in state.dendrogram.orig_dens}
+        return state.dendrogram.Z
+
+    def get_row_linkage(self):
+        return self._get_linkage(_ROW)
+
+    def get_col_linkage(self):
+        return self._get_linkage(_COL)
+
+    @property
+    def is_split(self):
+        return self.is_row_split | self.is_col_split
+
+    @property
+    def is_cluster(self):
+        return self.is_row_cluster | self.is_col_cluster
+
+    # --- deprecated, remove in the next minor ---
+    #
+    # Internal steps that autodoc exposed. Nothing in marsilea calls them and
+    # the reorder_* pair only accepts the intermediate structure that the old
+    # transform() built, so they are kept working rather than kept tidy.
+
+    def _deprecated(self, name, instead):
+        warnings.warn(
+            f"Deformation.{name} is an internal helper and will be removed, "
+            f"use {instead} instead",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+
+    def split_by_row(self, data: np.ndarray):
+        self._deprecated("split_by_row", "transform_row")
+        return self._split_chunks(_ROW, data)
+
+    def split_by_col(self, data: np.ndarray):
+        self._deprecated("split_by_col", "transform_col")
+        return self._split_chunks(_COL, data)
+
+    def split_cross(self, data: np.ndarray):
+        self._deprecated("split_cross", "transform")
+        if self.is_col_split & self.is_row_split:
+            return [
+                [data[ix1:ix2, iy1:iy2] for iy1, iy2 in pairwise(self.col_breakpoints)]
+                for ix1, ix2 in pairwise(self.row_breakpoints)
+            ]
+        if self.is_row_split:
+            return self._split_chunks(_ROW, data)
+        if self.is_col_split:
+            return self._split_chunks(_COL, data)
+        return data
+
+    def reorder_by_row(self, data, split="2d"):
+        self._deprecated("reorder_by_row", "transform_row")
+        self._run_cluster()
         if not self.is_row_cluster:
             return data
 
@@ -317,8 +451,8 @@ class Deformation:
             return data[self.row_reorder_index]
 
     def reorder_by_col(self, data, split="2d"):
+        self._deprecated("reorder_by_col", "transform_col")
         self._run_cluster()
-        # no cluster, return immediately
         if not self.is_col_cluster:
             return data
 
@@ -356,92 +490,3 @@ class Deformation:
                     return data[:, self.col_reorder_index]
                 else:
                     return data[self.col_reorder_index]
-
-    def transform(self, data: np.ndarray):
-        """data must be 2d array with the same shape as cluster data"""
-        if not data.shape == (self._nrow, self._ncol):
-            msg = (
-                f"The shape of input data {data.shape} does not align with"
-                f" the shape of cluster data {(self._nrow, self._ncol)}"
-            )
-            raise ValueError(msg)
-        if self.data_row_reindex is not None:
-            data = data[self.data_row_reindex]
-        if self.data_col_reindex is not None:
-            data = data[:, self.data_col_reindex]
-        trans_data = self.split_cross(data)
-        trans_data = self.reorder_by_row(trans_data, split="2d")
-        trans_data = self.reorder_by_col(trans_data, split="2d")
-        flatten_data = []
-        if self.is_row_split & self.is_col_split:
-            for chunk in trans_data:
-                flatten_data += chunk
-            return flatten_data
-        return trans_data
-
-    def transform_row(self, data: np.ndarray):
-        data = data.T
-        if data.ndim == 1:
-            assert len(data) == self._nrow
-        else:
-            assert data.shape[0] == self._nrow
-
-        if self.data_row_reindex is not None:
-            data = data[self.data_row_reindex]
-
-        trans_data = self.split_by_row(data)
-        trans_data = self.reorder_by_row(trans_data, split="1d")
-        if isinstance(trans_data, np.ndarray):
-            return trans_data.T
-        else:
-            return [d.T for d in trans_data]
-
-    def transform_col(self, data: np.ndarray):
-        if data.ndim == 1:
-            assert len(data) == self._ncol
-        else:
-            assert data.shape[1] == self._ncol
-
-        if self.data_col_reindex is not None:
-            if data.ndim == 2:
-                data = data[:, self.data_col_reindex]
-            else:
-                data = data[self.data_col_reindex]
-
-        trans_data = self.split_by_col(data)
-        trans_data = self.reorder_by_col(trans_data, split="1d")
-        return trans_data
-
-    def _get_dendrogram(self, axis):
-        # Update the cluster result
-        self._run_cluster()
-        return self._axes[axis].dendrogram
-
-    def get_row_dendrogram(self):
-        return self._get_dendrogram(_ROW)
-
-    def get_col_dendrogram(self):
-        return self._get_dendrogram(_COL)
-
-    def _get_linkage(self, axis):
-        state = self._axes[axis]
-        if state.dendrogram is None:
-            return None
-        if state.is_split:
-            # a single-element chunk has no linkage, its Z is None
-            return {x.key: x.Z for x in state.dendrogram.orig_dens}
-        return state.dendrogram.Z
-
-    def get_row_linkage(self):
-        return self._get_linkage(_ROW)
-
-    def get_col_linkage(self):
-        return self._get_linkage(_COL)
-
-    @property
-    def is_split(self):
-        return self.is_row_split | self.is_col_split
-
-    @property
-    def is_cluster(self):
-        return self.is_row_cluster | self.is_col_cluster

--- a/src/marsilea/base.py
+++ b/src/marsilea/base.py
@@ -1455,7 +1455,8 @@ class ClusterBoard(WhiteBoard):
 
         If the canvas is not split, the linkage matrix will be returned;
         otherwise, a dictionary of linkage matrix will be returned, the key is either
-        index or the name of each chunk.
+        index or the name of each chunk. A chunk with a single row has nothing
+        to merge and maps to None.
 
         """
         return self._deform.get_row_linkage()
@@ -1465,7 +1466,8 @@ class ClusterBoard(WhiteBoard):
 
         If the canvas is not split, the linkage matrix will be returned;
         otherwise, a dictionary of linkage matrix will be returned, the key is either
-        index or the name of each chunk.
+        index or the name of each chunk. A chunk with a single column has nothing
+        to merge and maps to None.
 
         """
         return self._deform.get_col_linkage()

--- a/src/marsilea/base.py
+++ b/src/marsilea/base.py
@@ -1036,6 +1036,8 @@ class ClusterBoard(WhiteBoard):
         colors=None,
         divider_style="--",
         meta_ratio=0.2,
+        height_scale=None,
+        height_transform=None,
         show=True,
         name=None,
         size=0.5,
@@ -1084,7 +1086,27 @@ class ClusterBoard(WhiteBoard):
         meta_color : color
             The color of the meta dendrogram
         meta_ratio : float
-            The size of meta dendrogram relative to the base dendrogram
+            The size of meta dendrogram relative to the base dendrogram.
+            Exact when `height_scale` is not the default "minmax".
+        height_scale : {"minmax", "group", "shared"}, default: "minmax"
+            What the merge heights are measured against.
+
+            - "minmax" stretches each group's own range over the full height,
+              so every group's dendrogram ends up the same height no matter
+              how tightly its rows actually cluster.
+            - "group" scales each group by its own tallest merge, keeping the
+              proportions inside a group honest.
+            - "shared" scales every group by the tallest merge anywhere, so
+              heights can be compared between groups and a tight group draws
+              genuinely short. Use this when the meta dendrogram looks
+              unbalanced against dense base dendrograms.
+        height_transform : {None, "sqrt", "log", "rank"} or callable
+            Bend the heights without reordering them, to spread out merges
+            that bunch up near the leaves. Worth reaching for with
+            ``method="ward"``, which is strongly bottom-heavy, and best left
+            alone with the default "single". A callable takes and returns an
+            array in [0, 1]. Requires `height_scale` other than "minmax", and
+            gives up readable distances in exchange for legibility.
         linewidth : float
             The linewidth for every dendrogram and divide line
         colors : color, array of color
@@ -1174,6 +1196,8 @@ class ClusterBoard(WhiteBoard):
             colors=colors,
             divider_style=divider_style,
             meta_ratio=meta_ratio,
+            height_scale=height_scale,
+            height_transform=height_transform,
             rasterized=rasterized,
         )
 
@@ -1413,6 +1437,8 @@ class ClusterBoard(WhiteBoard):
                         color=color,
                         linewidth=den["linewidth"],
                         rasterized=den["rasterized"],
+                        height_scale=den["height_scale"],
+                        height_transform=den["height_transform"],
                     )
                 else:
                     den_obj.draw(
@@ -1428,6 +1454,8 @@ class ClusterBoard(WhiteBoard):
                         divide_style=den["divider_style"],
                         meta_ratio=den["meta_ratio"],
                         rasterized=den["rasterized"],
+                        height_scale=den["height_scale"],
+                        height_transform=den["height_transform"],
                     )
 
     def _render_plan(self):

--- a/src/marsilea/dendrogram.py
+++ b/src/marsilea/dendrogram.py
@@ -5,7 +5,7 @@ from matplotlib.collections import LineCollection
 from matplotlib.colors import is_color_like
 from matplotlib.lines import Line2D
 from scipy.cluster.hierarchy import linkage as scipy_linkage, dendrogram
-from typing import List, Sequence
+from typing import List
 
 from .exceptions import PerformanceWarning
 
@@ -341,13 +341,11 @@ class GroupDendrogram(_DendrogramBase):
 
         den_xlim = 0
         ylim = 0
-        x_coords = []
         for den in self.dens:
             den_xlim += den.xrange
             dylim = den.yrange
             if dylim > ylim:
                 ylim = dylim
-            x_coords.append(den.root[0])
         self.den_xlim = den_xlim
         self.den_ylim = ylim
         self.divider = ylim * 1.05
@@ -409,65 +407,46 @@ class GroupDendrogram(_DendrogramBase):
 
         if spacing is None:
             spacing = [0 for _ in range(self.n - 1)]
-        elif not isinstance(spacing, Sequence):
+        elif np.ndim(spacing) == 0:
             spacing = [spacing for _ in range(self.n - 1)]
 
-        render_xlim = self.den_xlim / (1 - np.sum(spacing))
-        skeleton = np.sort(np.unique(self.x_coords[self.y_coords == 0]))
-        ranger = [(skeleton[i], skeleton[i + 1]) for i in range(len(skeleton) - 1)]
+        # mirrors layout._split, so the dendrogram lands on its data chunks
+        canvas_size = 1 - np.sum(spacing)
+        if canvas_size <= 0:
+            raise ValueError(
+                f"Spacing {np.sum(spacing)} leaves no room for the dendrograms, "
+                f"the total must be less than 1"
+            )
+        render_xlim = self.den_xlim / canvas_size
+
+        # scipy puts leaf i at icoord 5 + 10i, which __init__ divided by 5.
+        # Take the leaf positions from that rather than looking for zeros in y:
+        # a merge at height zero (two groups sharing a centroid) is not a leaf.
+        skeleton = 1.0 + 2.0 * np.arange(self.n_leaves)
 
         draw_dens = self.dens if add_meta else self.orig_dens
 
         if add_base:
             x_start = 0
             for i, den in enumerate(draw_dens):
-                if x_start != 0:
-                    den.set_lim(x_start=x_start, y_end=self.divider)
-                else:
-                    den.set_lim(y_end=self.divider)
+                den.set_lim(x_start=x_start, y_end=self.divider)
                 if i != self.n - 1:
                     x_start = x_start + den.xrange + spacing[i] * render_xlim
-            # get render x
-            # orient ?
+            # a meta leaf attaches to the apex of its base dendrogram
             skeleton_x = [den.render_root[0] for den in draw_dens]
-
         else:
+            # with no base to attach to, a meta leaf sits at its chunk centre
             xstart = 0
             skeleton_x = []
             for i, den in enumerate(draw_dens):
-                if i == 0:
-                    xstart += den.xrange / 2
-                else:
-                    xstart += den.xrange / 2 + spacing[i - 1] * render_xlim
-                skeleton_x.append(xstart)
-                xstart += den.xrange / 2
+                if i > 0:
+                    xstart += spacing[i - 1] * render_xlim
+                skeleton_x.append(xstart + den.xrange / 2)
+                xstart += den.xrange
 
-        mapper = dict(zip(skeleton, skeleton_x))
-        x_coords = np.sort(np.unique(self.x_coords.flatten()))
-
-        real_x = {}
-
-        ranger_ix = 0
-        for xc in x_coords:
-            render_coord = mapper.get(xc, None)
-            if render_coord is None:
-                while True:
-                    lower, upper = ranger[ranger_ix]
-                    real_up, real_low = mapper[upper], mapper[lower]
-                    if (xc > lower) & (xc < upper):
-                        ratio = (xc - lower) / (upper - lower)
-                        real_length = (real_up - real_low) * ratio
-                        render_coord = real_low + real_length
-                        real_x[xc] = render_coord
-                        break
-                    else:
-                        ranger_ix += 1
-            else:
-                real_x[xc] = render_coord
-
-        self._render_x_coords = np.asarray(
-            [real_x[i] for i in self.x_coords.flatten()]
-        ).reshape(self.x_coords.shape)
+        # leaves land on their skeleton position, internal nodes interpolate
+        # between the two they sit above
+        self._render_x_coords = np.interp(self.x_coords, skeleton, skeleton_x)
         if add_base:
             if add_meta:
                 norm_y_coords = self.y_coords  # / np.max(self.y_coords)
@@ -489,7 +468,7 @@ class GroupDendrogram(_DendrogramBase):
             )
 
         if divide & add_base & add_meta:
-            xmin = np.min(draw_dens[0].x_coords)
+            xmin = np.min(draw_dens[0]._render_x_coords)
             xmax = np.max(draw_dens[-1]._render_x_coords)
             if orient in ["top", "bottom"]:
                 ax.hlines(

--- a/src/marsilea/dendrogram.py
+++ b/src/marsilea/dendrogram.py
@@ -1,3 +1,4 @@
+import sys
 import warnings
 import numpy as np
 from itertools import cycle
@@ -42,6 +43,28 @@ def _compute_linkage(data, method, metric):
         return scipy_linkage(data, method=method, metric=metric)
 
 
+def _dendrogram_layout(Z):
+    """Get the drawing coordinates for a linkage matrix.
+
+    scipy walks the tree recursively, one frame per level, so a tall tree
+    overruns the interpreter's recursion limit. Single linkage chains, which
+    makes the depth grow with the leaf count: the default limit of 1000 is
+    already exhausted around 2500 leaves. Measured depth is ~0.65 frames per
+    leaf, so allow triple that and put the limit back afterwards.
+    """
+    # ponytail: raising the limit is enough for the tree sizes this library
+    # plots. Build icoord/dcoord iteratively if one ever outgrows the stack.
+    needed = 2 * len(Z) + 1000
+    limit = sys.getrecursionlimit()
+    if needed <= limit:
+        return dendrogram(Z, no_plot=True)
+    sys.setrecursionlimit(needed)
+    try:
+        return dendrogram(Z, no_plot=True)
+    finally:
+        sys.setrecursionlimit(limit)
+
+
 class _DendrogramBase:
     is_singleton = False
 
@@ -76,7 +99,7 @@ class _DendrogramBase:
                 self.Z = linkage
             else:
                 self.Z = _compute_linkage(data, method=method, metric=metric)
-            self._plot_data = dendrogram(self.Z, no_plot=True)
+            self._plot_data = _dendrogram_layout(self.Z)
 
             self.x_coords = np.asarray(self._plot_data["icoord"]) / 5
             self.y_coords = np.asarray(self._plot_data["dcoord"])

--- a/src/marsilea/dendrogram.py
+++ b/src/marsilea/dendrogram.py
@@ -83,16 +83,18 @@ class _DendrogramBase:
             if len(self.y_coords) == 1:
                 self.y_coords = np.array([[0.0, 0.75, 0.75, 0.0]])
             else:
-                ycoords = np.unique(self.y_coords)
-                ycoords = ycoords[np.nonzero(ycoords)]
-                y_min, y_max = np.min(ycoords), np.max(ycoords)
+                # leaf feet sit at 0 and must stay there; only merge heights
+                # are normalized, into [0.2, 1.2]
+                merges = self.y_coords != 0
+                heights = self.y_coords[merges]
+                y_min, y_max = heights.min(), heights.max()
                 interval = y_max - y_min
-                for i, j in zip(*np.nonzero(self.y_coords)):
-                    if self.y_coords[i, j] != 0.0:
-                        v = self.y_coords[i, j]
-                        self.y_coords[i, j] = (v - y_min) / interval + 0.2
-                    # self.y_coords[i, j] -= offset
-            # self.y_coords[np.nonzero(self.y_coords)] - offset
+                if interval == 0:
+                    # every merge happened at the same distance, so there is no
+                    # spread to normalize against
+                    self.y_coords[merges] = 1.2
+                else:
+                    self.y_coords[merges] = (heights - y_min) / interval + 0.2
 
         self._render_x_coords = self.x_coords
         self._render_y_coords = self.y_coords

--- a/src/marsilea/dendrogram.py
+++ b/src/marsilea/dendrogram.py
@@ -69,6 +69,8 @@ class _DendrogramBase:
             self.y_coords = np.array([[0.0, 0.75, 0.75, 0.0]])
             self._reorder_index = np.array([0])
             self.is_singleton = True
+            # a single observation never merges, so there is no linkage
+            self.Z = None
         else:
             if linkage is not None:
                 self.Z = linkage

--- a/src/marsilea/dendrogram.py
+++ b/src/marsilea/dendrogram.py
@@ -52,8 +52,8 @@ def _dendrogram_layout(Z):
     already exhausted around 2500 leaves. Measured depth is ~0.65 frames per
     leaf, so allow triple that and put the limit back afterwards.
     """
-    # ponytail: raising the limit is enough for the tree sizes this library
-    # plots. Build icoord/dcoord iteratively if one ever outgrows the stack.
+    # Raising the limit covers the tree sizes this library plots. If one ever
+    # outgrows the stack, replace this with an iterative icoord/dcoord builder.
     needed = 2 * len(Z) + 1000
     limit = sys.getrecursionlimit()
     if needed <= limit:
@@ -419,12 +419,13 @@ class Dendrogram(_DendrogramBase):
         root_color = color if root_color is None else root_color
         linewidth = 0.7 if linewidth is None else linewidth
 
-        if control_ax:
-            # standing on its own; inside a GroupDendrogram the group has
-            # already scaled us against its other members
+        if height_scale is not None or height_transform is not None:
             self.set_height_scale(
                 _resolve_height_scale(height_scale, self.y_coords, height_transform)
             )
+        # asking for neither leaves the heights alone, which is what a
+        # GroupDendrogram needs: it has already scaled this dendrogram against
+        # its sibling groups before handing it the axes
 
         self._draw_dendrogram(
             ax, orient=orient, color=color, linewidth=linewidth, rasterized=rasterized
@@ -580,6 +581,11 @@ class GroupDendrogram(_DendrogramBase):
             spacing = [0 for _ in range(self.n - 1)]
         elif np.ndim(spacing) == 0:
             spacing = [spacing for _ in range(self.n - 1)]
+        elif len(spacing) != self.n - 1:
+            raise ValueError(
+                f"Got {len(spacing)} spacings for {self.n} dendrograms, "
+                f"expected {self.n - 1}, one for each gap between them"
+            )
 
         # mirrors layout._split, so the dendrogram lands on its data chunks
         canvas_size = 1 - np.sum(spacing)

--- a/src/marsilea/dendrogram.py
+++ b/src/marsilea/dendrogram.py
@@ -65,6 +65,105 @@ def _dendrogram_layout(Z):
         sys.setrecursionlimit(limit)
 
 
+#: Default for :meth:`ClusterBoard.add_dendrogram`; kept at the legacy
+#: behaviour so existing figures do not move. See the height scaling how-to.
+DEFAULT_HEIGHT_SCALE = "minmax"
+
+_HEIGHT_SCALES = ("minmax", "group", "shared")
+
+_HEIGHT_TRANSFORMS = {
+    "linear": lambda u: u,
+    "sqrt": np.sqrt,
+    "log": lambda u: np.log1p(9.0 * u) / np.log(10.0),
+}
+
+
+class _HeightScale:
+    """Map raw merge heights onto ``[0, 1]``.
+
+    *pool* is the set of heights the scale is calibrated against, and choosing
+    it is the whole game: one dendrogram's own heights make each group fill the
+    space it is given, every group's heights pooled together make the groups
+    comparable by eye.
+
+    *transform* bends the result without reordering it. Merge heights are often
+    bunched at the bottom, badly so for ward linkage, which leaves the top of
+    the plot empty; ``"sqrt"`` and ``"log"`` open the low end up and ``"rank"``
+    spreads the merges evenly. All of them trade away readable distances.
+    """
+
+    def __init__(self, pool, transform=None):
+        pool = np.asarray(pool, dtype=float).ravel()
+        self.pool = np.unique(pool[pool > 0])
+        self.transform = transform
+
+    def _bend(self, u):
+        if self.transform is None:
+            return u
+        if callable(self.transform):
+            return np.asarray(self.transform(u), dtype=float)
+        return _HEIGHT_TRANSFORMS[self.transform](u)
+
+    def __call__(self, y_coords):
+        scaled = np.zeros_like(y_coords, dtype=float)
+        merges = y_coords > 0
+        if len(self.pool) == 0 or not merges.any():
+            # nothing ever merged, every leaf is drawn flat on the baseline
+            return scaled
+        if self.transform == "rank":
+            scaled[merges] = (
+                np.searchsorted(self.pool, y_coords[merges], side="right")
+                / self.pool.size
+            )
+        else:
+            scaled[merges] = self._bend(
+                np.clip(y_coords[merges] / self.pool[-1], 0.0, 1.0)
+            )
+        return scaled
+
+
+def _base_scales(dens, scale, transform):
+    """One height scale per base dendrogram.
+
+    A shared scale is calibrated on every group's heights at once, which is
+    what lets two groups be compared by eye; a group scale calibrates each on
+    its own, and the legacy min-max gives back None.
+    """
+    if scale is None:
+        scale = DEFAULT_HEIGHT_SCALE
+    if scale == "shared":
+        pool = np.concatenate([den.y_coords.ravel() for den in dens])
+        return [_resolve_height_scale(scale, pool, transform)] * len(dens)
+    return [_resolve_height_scale(scale, den.y_coords, transform) for den in dens]
+
+
+def _resolve_height_scale(scale, pool, transform):
+    """None means the legacy per-group min-max, anything else is a scale."""
+    if scale is None:
+        scale = DEFAULT_HEIGHT_SCALE
+    if scale not in _HEIGHT_SCALES:
+        raise ValueError(
+            f"Unknown height_scale {scale!r}, expected one of {_HEIGHT_SCALES}"
+        )
+    if not (transform is None or callable(transform)) and (
+        transform not in _HEIGHT_TRANSFORMS and transform != "rank"
+    ):
+        expected = (*_HEIGHT_TRANSFORMS, "rank")
+        raise ValueError(
+            f"Unknown height_transform {transform!r}, expected one of {expected}, "
+            f"a callable, or None"
+        )
+    if scale == "minmax":
+        if transform is not None:
+            raise ValueError(
+                "height_transform needs height_scale='group' or 'shared'; the "
+                "default 'minmax' scaling stretches every group to the same "
+                "height, so there is nothing left for a transform to do"
+            )
+        return None
+    return _HeightScale(pool, transform=transform)
+
+
 class _DendrogramBase:
     is_singleton = False
 
@@ -86,13 +185,12 @@ class _DendrogramBase:
             metric = "euclidean"
         # edge case: data is 1d, may happen when user split the data
         if len(data) == 1:
-            # TODO: the y coords are heuristic value,
-            #       need a better way to handle
             self.x_coords = np.array([[1.0, 1.0, 1.0, 1.0]])
-            self.y_coords = np.array([[0.0, 0.75, 0.75, 0.0]])
+            # a lone observation never merges, so every height is truly zero
+            self.y_coords = np.zeros((1, 4))
             self._reorder_index = np.array([0])
             self.is_singleton = True
-            # a single observation never merges, so there is no linkage
+            # ... and for the same reason there is no linkage
             self.Z = None
         else:
             if linkage is not None:
@@ -102,34 +200,19 @@ class _DendrogramBase:
             self._plot_data = _dendrogram_layout(self.Z)
 
             self.x_coords = np.asarray(self._plot_data["icoord"]) / 5
-            self.y_coords = np.asarray(self._plot_data["dcoord"])
+            # kept as scipy reports them, in the metric's own units; how they
+            # map onto the axis is decided later by set_height_scale
+            self.y_coords = np.asarray(self._plot_data["dcoord"], dtype=float)
             self._reorder_index = self._plot_data["leaves"]
 
-            if len(self.y_coords) == 1:
-                self.y_coords = np.array([[0.0, 0.75, 0.75, 0.0]])
-            else:
-                # leaf feet sit at 0 and must stay there; only merge heights
-                # are normalized, into [0.2, 1.2]
-                merges = self.y_coords != 0
-                heights = self.y_coords[merges]
-                y_min, y_max = heights.min(), heights.max()
-                interval = y_max - y_min
-                if interval == 0:
-                    # every merge happened at the same distance, so there is no
-                    # spread to normalize against
-                    self.y_coords[merges] = 1.2
-                else:
-                    self.y_coords[merges] = (heights - y_min) / interval + 0.2
-
+        self.max_height = float(np.max(self.y_coords))
         self._render_x_coords = self.x_coords
-        self._render_y_coords = self.y_coords
         self.n_leaves = len(self.reorder_index)
-        self.max_dependent_coord = np.max(self.y_coords)
 
         self.xlim = np.array([0, self.n_leaves * 2])
-        self.ylim = np.array([0, self.max_dependent_coord * 1.05])
         self._render_xlim = self.xlim
-        self._render_ylim = self.ylim
+        # drawable on its own; a GroupDendrogram rescales its members itself
+        self.set_height_scale(None)
 
         # Should be lazy eval
         # TODO: Allow center to be calculated differently
@@ -147,6 +230,50 @@ class _DendrogramBase:
                 )
         else:
             raise TypeError("The get_meta_center must be a callable function or None.")
+
+    def _minmax_heights(self):
+        """Legacy scaling: stretch this tree's own range onto ``[0.2, 1.2]``.
+
+        Every dendrogram then ends up exactly as tall as every other one,
+        whatever its real spread, which is what ``height_scale="shared"``
+        exists to undo.
+        """
+        merges = self.y_coords != 0
+        if len(self.y_coords) == 1 or not merges.any():
+            # one merge, or none at all, leaves nothing to stretch
+            return np.array([[0.0, 0.75, 0.75, 0.0]])
+        scaled = self.y_coords.copy()
+        heights = self.y_coords[merges]
+        y_min, y_max = heights.min(), heights.max()
+        interval = y_max - y_min
+        if interval == 0:
+            # every merge happened at the same distance, so there is no
+            # spread to normalize against
+            scaled[merges] = 1.2
+        else:
+            scaled[merges] = (heights - y_min) / interval + 0.2
+        return scaled
+
+    def set_height_scale(self, scale, band=1.0, offset=0.0):
+        """Place the merge heights on the drawn axis.
+
+        *scale* maps raw heights onto ``[0, 1]``; the result is stretched to
+        *band* and lifted by *offset*. Passing None keeps the legacy per-group
+        min-max normalization.
+
+        Only the render coordinates are derived, so this can be called again
+        with a different scale without losing the original heights.
+        """
+        if scale is None:
+            scaled = self._minmax_heights()
+            headroom = 1.05
+        else:
+            scaled = band * scale(self.y_coords)
+            headroom = 1.0
+        self._render_y_coords = scaled + offset
+        self.max_dependent_coord = float(np.max(scaled))
+        self.ylim = np.array([0.0, self.max_dependent_coord * headroom])
+        self._render_ylim = self.ylim
 
     @property
     def xrange(self):
@@ -262,6 +389,8 @@ class Dendrogram(_DendrogramBase):
         root_color=None,
         control_ax=True,
         rasterized=False,
+        height_scale=None,
+        height_transform=None,
         **kwargs,
     ):
         """
@@ -289,6 +418,13 @@ class Dendrogram(_DendrogramBase):
         color = ".1" if color is None else color
         root_color = color if root_color is None else root_color
         linewidth = 0.7 if linewidth is None else linewidth
+
+        if control_ax:
+            # standing on its own; inside a GroupDendrogram the group has
+            # already scaled us against its other members
+            self.set_height_scale(
+                _resolve_height_scale(height_scale, self.y_coords, height_transform)
+            )
 
         self._draw_dendrogram(
             ax, orient=orient, color=color, linewidth=linewidth, rasterized=rasterized
@@ -362,16 +498,11 @@ class GroupDendrogram(_DendrogramBase):
         self.dens = np.asarray(dens)[self.reorder_index]
         self.n = len(self.dens)
 
-        den_xlim = 0
-        ylim = 0
-        for den in self.dens:
-            den_xlim += den.xrange
-            dylim = den.yrange
-            if dylim > ylim:
-                ylim = dylim
-        self.den_xlim = den_xlim
-        self.den_ylim = ylim
-        self.divider = ylim * 1.05
+        self.den_xlim = sum(den.xrange for den in self.dens)
+        # how tall the bases end up, and so where the divider sits, depends on
+        # the height scale the caller asks for; draw() fills these in
+        self.den_ylim = None
+        self.divider = None
 
     def draw(
         self,
@@ -387,6 +518,8 @@ class GroupDendrogram(_DendrogramBase):
         divide_style="--",
         meta_ratio=0.2,
         rasterized=False,
+        height_scale=None,
+        height_transform=None,
     ):
         """
 
@@ -411,9 +544,24 @@ class GroupDendrogram(_DendrogramBase):
         divide_style :
             The linestyle of the divide line
         meta_ratio : float
-            The size of meta dendrogram relative to the base dendrogram
-        rasterized : bool
-            Rasterize the dendrogram to speed up rendering
+            The size of meta dendrogram relative to the base dendrogram.
+            Exact unless `height_scale` is "minmax".
+        height_scale : {"minmax", "group", "shared"}, default: "minmax"
+            What the merge heights are measured against. "minmax" stretches
+            each group over the full height, so every group looks equally
+            deep; "shared" measures them all against the tallest merge
+            anywhere, so the heights can be compared between groups.
+        height_transform : {None, "sqrt", "log", "rank"} or callable
+            Bend the heights without reordering them, to spread out merges
+            that bunch up near the leaves. Needs `height_scale` other than
+            "minmax".
+
+        .. note::
+
+            With `add_base` on, a meta leaf attaches to the apex of its base
+            dendrogram; with it off, there is no apex to attach to and the
+            leaf sits at the centre of its chunk instead, so the meta
+            dendrogram shifts slightly between the two.
 
         """
 
@@ -449,6 +597,14 @@ class GroupDendrogram(_DendrogramBase):
 
         draw_dens = self.dens if add_meta else self.orig_dens
 
+        # scale the bases first: the divider sits on top of the tallest one
+        scales = _base_scales(draw_dens, height_scale, height_transform)
+        legacy = scales[0] is None
+        for den, scale in zip(draw_dens, scales):
+            den.set_height_scale(scale)
+        self.den_ylim = max(den.yrange for den in draw_dens)
+        self.divider = self.den_ylim * (1.05 if legacy else 1.0)
+
         if add_base:
             x_start = 0
             for i, den in enumerate(draw_dens):
@@ -470,15 +626,31 @@ class GroupDendrogram(_DendrogramBase):
         # leaves land on their skeleton position, internal nodes interpolate
         # between the two they sit above
         self._render_x_coords = np.interp(self.x_coords, skeleton, skeleton_x)
+        meta_scale = _resolve_height_scale(
+            height_scale, self.y_coords, height_transform
+        )
         if add_base:
             if add_meta:
-                norm_y_coords = self.y_coords  # / np.max(self.y_coords)
-                amplify = self.den_ylim * meta_ratio
-                self._render_y_coords = norm_y_coords * amplify + self.divider
+                if legacy:
+                    amplify = self.den_ylim * meta_ratio
+                    self._render_y_coords = (
+                        self._minmax_heights() * amplify + self.divider
+                    )
+                else:
+                    # meta leaves land exactly on the divider and the apex
+                    # exactly meta_ratio above it, so the knob means what it says
+                    self.set_height_scale(
+                        meta_scale,
+                        band=meta_ratio * self.divider,
+                        offset=self.divider,
+                    )
             else:
-                self._render_y_coords = self.den_ylim
+                self._render_y_coords = np.full_like(self.y_coords, self.den_ylim)
         else:
-            self._render_y_coords = self.y_coords / 5
+            if legacy:
+                self._render_y_coords = self._minmax_heights() / 5
+            else:
+                self.set_height_scale(meta_scale)
 
         if add_meta:
             # Add meta dendrogram
@@ -531,7 +703,7 @@ class GroupDendrogram(_DendrogramBase):
 
         xlim = render_xlim
         # reserve room to avoid clipping of the top
-        ylim = np.max(self._render_y_coords) * 1.05
+        ylim = np.max(self._render_y_coords) * (1.05 if legacy else 1.02)
         if orient in ["right", "left"]:
             xlim, ylim = ylim, xlim
 

--- a/tests/test_deform.py
+++ b/tests/test_deform.py
@@ -299,3 +299,14 @@ def test_deepcopy_is_independent():
     assert not original.is_row_split
     assert isinstance(original.transform_row(np.arange(N)), np.ndarray)
     assert len(clone.transform_row(np.arange(N))) == 2
+
+
+def test_chunk_order_moves_data_and_ratios_together():
+    """set_*_chunk_order used to reorder the axis widths but not the data."""
+    deform = Deformation(np.arange(N * M, dtype=float).reshape(N, M))
+    deform.set_split_row([3])
+    deform.set_row_chunk_order([1, 0])
+
+    chunks = deform.transform_row(np.arange(N))
+    assert [c.tolist() for c in chunks] == [[3, 4, 5, 6, 7], [0, 1, 2]]
+    assert deform.row_ratios.tolist() == [len(c) for c in chunks]

--- a/tests/test_deform.py
+++ b/tests/test_deform.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from itertools import product
 
 import pytest
@@ -7,12 +8,10 @@ from marsilea import Deformation
 matrix = np.random.randn(7, 5)
 
 col1d = np.array([1, 2, 3, 4, 5])
-col2d = np.array([[1, 2, 3, 4, 5],
-                  [1, 2, 3, 4, 5]])
+col2d = np.array([[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]])
 
 row1d = np.array([1, 2, 3, 4, 5, 6, 7])
-row2d = np.array([[1, 2, 3, 4, 5, 6, 7],
-                  [1, 2, 3, 4, 5, 6, 7]])
+row2d = np.array([[1, 2, 3, 4, 5, 6, 7], [1, 2, 3, 4, 5, 6, 7]])
 
 row_cluster = [True, False]
 col_cluster = [True, False]
@@ -22,9 +21,9 @@ split_col = [True, False]
 
 @pytest.mark.parametrize(
     "row_cluster,col_cluster,split_row,split_col,tdata",
-    product(row_cluster, col_cluster, split_row, split_col, [col1d, col2d]))
-def test_deform_trans_col(row_cluster, col_cluster, split_row, split_col,
-                          tdata):
+    product(row_cluster, col_cluster, split_row, split_col, [col1d, col2d]),
+)
+def test_deform_trans_col(row_cluster, col_cluster, split_row, split_col, tdata):
     deform = Deformation(matrix)
     deform.set_cluster(col=col_cluster, row=row_cluster)
     if split_col:
@@ -45,9 +44,9 @@ def test_deform_trans_col(row_cluster, col_cluster, split_row, split_col,
 
 @pytest.mark.parametrize(
     "row_cluster,col_cluster,split_row,split_col,tdata",
-    product(row_cluster, col_cluster, split_row, split_col, [row1d, row2d]))
-def test_deform_trans_row(row_cluster, col_cluster, split_row, split_col,
-                          tdata):
+    product(row_cluster, col_cluster, split_row, split_col, [row1d, row2d]),
+)
+def test_deform_trans_row(row_cluster, col_cluster, split_row, split_col, tdata):
     deform = Deformation(matrix)
     deform.set_cluster(col=col_cluster, row=row_cluster)
     if split_col:
@@ -68,7 +67,8 @@ def test_deform_trans_row(row_cluster, col_cluster, split_row, split_col,
 
 @pytest.mark.parametrize(
     "row_cluster,col_cluster,split_row,split_col",
-    product(row_cluster, col_cluster, split_row, split_col))
+    product(row_cluster, col_cluster, split_row, split_col),
+)
 def test_deform_trans_both(row_cluster, col_cluster, split_row, split_col):
     deform = Deformation(matrix)
     deform.set_cluster(col=col_cluster, row=row_cluster)
@@ -90,3 +90,212 @@ def test_deform_trans_both(row_cluster, col_cluster, split_row, split_col):
                 total += i.size
 
     assert total == matrix.size
+
+
+# --- Characterization: the exact permutation, not just the element count ---
+#
+# The tests above only assert that no data is lost. They pass just as happily
+# when rows come out in the wrong order, which is the one thing this module
+# exists to get right. Everything below pins the actual permutation.
+
+N, M = 8, 6
+GEOM = np.random.default_rng(42).standard_normal((N, M))
+GROUP_ROW = list("aabbbccc")
+GROUP_COL = list("xxyyyy")
+
+# Captured from the implementation before the dendrogram refactor. Keys are
+# "<mode>-<row_cluster><col_cluster><split_row><split_col>" as 0/1 flags.
+GOLDEN = {
+    "cut-1111": ([[0, 1, 2], [5, 3, 6, 4, 7]], [[0, 1], [4, 5, 2, 3]]),
+    "cut-1110": ([[0, 1, 2], [5, 3, 6, 4, 7]], [3, 1, 2, 0, 4, 5]),
+    "cut-1101": ([0, 2, 5, 1, 3, 6, 4, 7], [[0, 1], [4, 5, 2, 3]]),
+    "cut-1100": ([0, 2, 5, 1, 3, 6, 4, 7], [3, 1, 2, 0, 4, 5]),
+    "cut-1011": ([[0, 1, 2], [5, 3, 6, 4, 7]], [[0, 1], [2, 3, 4, 5]]),
+    "cut-1010": ([[0, 1, 2], [5, 3, 6, 4, 7]], [0, 1, 2, 3, 4, 5]),
+    "cut-1001": ([0, 2, 5, 1, 3, 6, 4, 7], [[0, 1], [2, 3, 4, 5]]),
+    "cut-1000": ([0, 2, 5, 1, 3, 6, 4, 7], [0, 1, 2, 3, 4, 5]),
+    "cut-0111": ([[0, 1, 2], [3, 4, 5, 6, 7]], [[0, 1], [4, 5, 2, 3]]),
+    "cut-0110": ([[0, 1, 2], [3, 4, 5, 6, 7]], [3, 1, 2, 0, 4, 5]),
+    "cut-0101": ([0, 1, 2, 3, 4, 5, 6, 7], [[0, 1], [4, 5, 2, 3]]),
+    "cut-0100": ([0, 1, 2, 3, 4, 5, 6, 7], [3, 1, 2, 0, 4, 5]),
+    "cut-0011": ([[0, 1, 2], [3, 4, 5, 6, 7]], [[0, 1], [2, 3, 4, 5]]),
+    "cut-0010": ([[0, 1, 2], [3, 4, 5, 6, 7]], [0, 1, 2, 3, 4, 5]),
+    "cut-0001": ([0, 1, 2, 3, 4, 5, 6, 7], [[0, 1], [2, 3, 4, 5]]),
+    "cut-0000": ([0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5]),
+    "group-1111": ([[0, 1], [4, 2, 3], [5, 6, 7]], [[0, 1], [4, 5, 2, 3]]),
+    "group-1110": ([[0, 1], [4, 2, 3], [5, 6, 7]], [3, 1, 2, 0, 4, 5]),
+    "group-1101": ([0, 2, 5, 1, 3, 6, 4, 7], [[0, 1], [4, 5, 2, 3]]),
+    "group-1100": ([0, 2, 5, 1, 3, 6, 4, 7], [3, 1, 2, 0, 4, 5]),
+    "group-1011": ([[0, 1], [4, 2, 3], [5, 6, 7]], [[0, 1], [2, 3, 4, 5]]),
+    "group-1010": ([[0, 1], [4, 2, 3], [5, 6, 7]], [0, 1, 2, 3, 4, 5]),
+    "group-1001": ([0, 2, 5, 1, 3, 6, 4, 7], [[0, 1], [2, 3, 4, 5]]),
+    "group-1000": ([0, 2, 5, 1, 3, 6, 4, 7], [0, 1, 2, 3, 4, 5]),
+    "group-0111": ([[0, 1], [2, 3, 4], [5, 6, 7]], [[0, 1], [4, 5, 2, 3]]),
+    "group-0110": ([[0, 1], [2, 3, 4], [5, 6, 7]], [3, 1, 2, 0, 4, 5]),
+    "group-0101": ([0, 1, 2, 3, 4, 5, 6, 7], [[0, 1], [4, 5, 2, 3]]),
+    "group-0100": ([0, 1, 2, 3, 4, 5, 6, 7], [3, 1, 2, 0, 4, 5]),
+    "group-0011": ([[0, 1], [2, 3, 4], [5, 6, 7]], [[0, 1], [2, 3, 4, 5]]),
+    "group-0010": ([[0, 1], [2, 3, 4], [5, 6, 7]], [0, 1, 2, 3, 4, 5]),
+    "group-0001": ([0, 1, 2, 3, 4, 5, 6, 7], [[0, 1], [2, 3, 4, 5]]),
+    "group-0000": ([0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5]),
+}
+
+CASES = [
+    (mode, rc, cc, sr, sc)
+    for mode in ("cut", "group")
+    for rc, cc, sr, sc in product([True, False], repeat=4)
+]
+
+
+def _group_split(deform, labels, axis):
+    """Reproduce what ClusterBoard.group_rows/group_cols does to a Deformation."""
+    uni, idx = np.unique(labels, return_inverse=True)
+    reindex = np.argsort(idx, kind="stable")
+    breakpoints = np.cumsum(np.bincount(idx))[:-1]
+    if axis == "row":
+        deform.set_data_row_reindex(reindex)
+        deform.set_split_row(breakpoints, order=uni)
+    else:
+        deform.set_data_col_reindex(reindex)
+        deform.set_split_col(breakpoints, order=uni)
+
+
+def build(mode, row_cluster, col_cluster, split_row, split_col):
+    deform = Deformation(GEOM)
+    deform.set_cluster(col=col_cluster, row=row_cluster)
+    if mode == "cut":
+        if split_row:
+            deform.set_split_row([3])
+        if split_col:
+            deform.set_split_col([2])
+    else:
+        if split_row:
+            _group_split(deform, GROUP_ROW, "row")
+        if split_col:
+            _group_split(deform, GROUP_COL, "col")
+    return deform
+
+
+def as_lists(result):
+    if isinstance(result, np.ndarray):
+        return result.tolist()
+    return [np.asarray(chunk).tolist() for chunk in result]
+
+
+def flatten(result):
+    """Chunked or not, give back one flat order."""
+    if isinstance(result, np.ndarray):
+        return result.tolist()
+    return [i for chunk in result for i in np.asarray(chunk).tolist()]
+
+
+def case_id(case):
+    mode, rc, cc, sr, sc = case
+    return f"{mode}-{int(rc)}{int(cc)}{int(sr)}{int(sc)}"
+
+
+@pytest.mark.parametrize("case", CASES, ids=case_id)
+def test_permutation_matches_golden(case):
+    """The exact row/col order must not drift."""
+    deform = build(*case)
+    expect_row, expect_col = GOLDEN[case_id(case)]
+    assert as_lists(deform.transform_row(np.arange(N))) == expect_row
+    assert as_lists(deform.transform_col(np.arange(M))) == expect_col
+
+
+@pytest.mark.parametrize("case", CASES, ids=case_id)
+def test_main_and_side_agree(case):
+    """A side plot's order must equal the main canvas's order.
+
+    This is the whole point of the module: the heatmap body and every flank
+    plot are deformed by separate calls and have to land on the same rows.
+    """
+    deform = build(*case)
+    marker = np.arange(N * M).reshape(N, M)
+    body = deform.transform(marker)
+    row_chunks = deform.transform_row(np.arange(N))
+    col_chunks = deform.transform_col(np.arange(M))
+
+    n_col_chunks = 1 if isinstance(col_chunks, np.ndarray) else len(col_chunks)
+    blocks = [np.asarray(b) for b in ([body] if isinstance(body, np.ndarray) else body)]
+    # transform flattens a 2D split row-major, so the first block of each grid
+    # row carries the row order and the first grid row carries the column order
+    body_rows = [i for b in blocks[::n_col_chunks] for i in (b[:, 0] // M).tolist()]
+    body_cols = [j for b in blocks[:n_col_chunks] for j in (b[0, :] % M).tolist()]
+
+    assert body_rows == flatten(row_chunks)
+    assert body_cols == flatten(col_chunks)
+
+
+@pytest.mark.parametrize("case", CASES, ids=case_id)
+def test_ratios_match_chunk_sizes(case):
+    """Axis split ratios must match the chunk sizes the data is cut into."""
+    deform = build(*case)
+    for ratios, chunks, total in [
+        (deform.row_ratios, deform.transform_row(np.arange(N)), N),
+        (deform.col_ratios, deform.transform_col(np.arange(M)), M),
+    ]:
+        if ratios is None:
+            assert isinstance(chunks, np.ndarray)
+            continue
+        assert list(ratios) == [len(c) for c in chunks]
+        assert sum(ratios) == total
+
+
+@pytest.mark.parametrize("case", CASES, ids=case_id)
+def test_transform_is_idempotent_and_leaves_input_alone(case):
+    deform = build(*case)
+    marker = np.arange(N * M).reshape(N, M)
+    untouched = marker.copy()
+
+    first = as_lists(deform.transform(marker))
+    assert np.array_equal(marker, untouched), "transform mutated its input"
+    assert as_lists(deform.transform(marker)) == first
+
+
+def test_cluster_runs_once():
+    """Clustering is the expensive part; it must stay memoized."""
+    deform = build("cut", True, True, True, True)
+    calls = {"row": 0, "col": 0}
+    real_row, real_col = deform.cluster_row, deform.cluster_col
+
+    def counting_row():
+        calls["row"] += 1
+        return real_row()
+
+    def counting_col():
+        calls["col"] += 1
+        return real_col()
+
+    deform.cluster_row, deform.cluster_col = counting_row, counting_col
+
+    for _ in range(3):
+        deform.transform(GEOM)
+        deform.transform_row(np.arange(N))
+        deform.transform_col(np.arange(M))
+        _, _ = deform.row_ratios, deform.col_ratios
+
+    assert calls == {"row": 1, "col": 1}
+
+
+def test_instances_do_not_share_state():
+    """State must be per-instance, not class-level."""
+    first, second = Deformation(GEOM), Deformation(GEOM)
+    first.set_cluster(row=True, method="ward")
+    first.set_split_row([3])
+
+    assert second.row_cluster_kws == {}
+    assert not second.is_row_split
+    assert not second.is_row_cluster
+    assert second.row_breakpoints is None
+
+
+def test_deepcopy_is_independent():
+    """ClusterBoard deep-copies its Deformation; the copy must detach cleanly."""
+    original = build("cut", True, True, False, False)
+    clone = deepcopy(original)
+    clone.set_split_row([3])
+
+    assert not original.is_row_split
+    assert isinstance(original.transform_row(np.arange(N)), np.ndarray)
+    assert len(clone.transform_row(np.arange(N))) == 2

--- a/tests/test_dendrogram.py
+++ b/tests/test_dendrogram.py
@@ -155,7 +155,6 @@ def test_base_roots_stay_inside_their_own_slot(group_den):
 # --- Degenerate inputs ---
 
 
-@pytest.mark.xfail(reason="interval == 0 divides by zero -> NaN ylim", strict=True)
 def test_equal_merge_heights_do_not_produce_nan():
     """All merge heights equal makes the min-max interval zero."""
     data = np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [1.0, 1.0]])

--- a/tests/test_dendrogram.py
+++ b/tests/test_dendrogram.py
@@ -163,7 +163,6 @@ def test_equal_merge_heights_do_not_produce_nan():
     assert np.isfinite(den.max_dependent_coord)
 
 
-@pytest.mark.xfail(reason="zero-height merge breaks the y==0 leaf mask", strict=True)
 def test_identical_group_centroids_can_be_drawn():
     """Two groups with the same centroid merge at height zero."""
     rng = np.random.default_rng(7)

--- a/tests/test_dendrogram.py
+++ b/tests/test_dendrogram.py
@@ -193,3 +193,166 @@ def test_linkage_readable_with_a_singleton_group():
     linkages = board.get_row_linkage()
     assert set(linkages) == {"a", "b"}
     assert linkages["b"] is None
+
+
+# --- Height scaling ---
+
+
+@pytest.fixture
+def uneven_groups():
+    """Three groups whose rows cluster at very different tightness."""
+
+    def build():
+        rng = np.random.default_rng(0)
+        return [
+            Dendrogram(rng.standard_normal((n, 4)) * s, method="average")
+            for n, s in [(5, 0.02), (14, 3.0), (6, 1.0)]
+        ]
+
+    return build
+
+
+def test_shared_scale_keeps_the_ratio_of_real_distances(uneven_groups):
+    """A group that clusters tightly should draw short, not full height."""
+    gd = GroupDendrogram(uneven_groups(), method="average")
+    fig, ax = plt.subplots()
+    gd.draw(ax, height_scale="shared")
+
+    tallest = max(d.max_height for d in gd.dens)
+    for den in gd.dens:
+        assert den.render_root[1] / gd.divider == pytest.approx(
+            den.max_height / tallest
+        )
+
+
+def test_minmax_scale_pins_every_apex(uneven_groups):
+    """The contrast case: the legacy scale erases that spread."""
+    gd = GroupDendrogram(uneven_groups(), method="average")
+    fig, ax = plt.subplots()
+    gd.draw(ax, height_scale="minmax")
+    assert [d.render_root[1] for d in gd.dens] == pytest.approx([1.2, 1.2, 1.2])
+
+
+@pytest.mark.parametrize("meta_ratio", [0.1, 0.2, 0.5])
+@pytest.mark.parametrize("scale", ["group", "shared"])
+def test_meta_ratio_is_exact(uneven_groups, scale, meta_ratio):
+    """Drawn meta height over drawn base height must be meta_ratio."""
+    gd = GroupDendrogram(uneven_groups(), method="average")
+    fig, ax = plt.subplots()
+    gd.draw(ax, height_scale=scale, meta_ratio=meta_ratio)
+
+    span = gd._render_y_coords.max() - gd.divider
+    assert span / gd.divider == pytest.approx(meta_ratio)
+    # meta leaves sit on the divider, with no dead gap below them
+    assert gd._render_y_coords.min() == pytest.approx(gd.divider)
+
+
+@pytest.mark.parametrize("transform", [None, "sqrt", "log", "rank"])
+@pytest.mark.parametrize("scale", ["group", "shared"])
+def test_transforms_never_reorder_merges(scale, transform):
+    """A transform may bend the heights but must not swap any two merges."""
+    data = np.random.default_rng(1).standard_normal((30, 5))
+    den = Dendrogram(data, method="ward")
+    raw = den.y_coords[den.y_coords > 0]
+
+    fig, ax = plt.subplots()
+    den.draw(ax, height_scale=scale, height_transform=transform)
+    drawn = den._render_y_coords[den.y_coords > 0]
+
+    assert np.array_equal(np.argsort(np.argsort(raw)), np.argsort(np.argsort(drawn)))
+
+
+def test_transform_lifts_a_bottom_heavy_tree():
+    """The point of the transform: ward bunches merges near the leaves."""
+    data = np.random.default_rng(1).standard_normal((60, 5))
+    den = Dendrogram(data, method="ward")
+
+    def below_half(transform):
+        fig, ax = plt.subplots()
+        den.draw(ax, height_scale="group", height_transform=transform)
+        drawn = den._render_y_coords[den.y_coords > 0]
+        return np.mean(drawn < 0.5 * drawn.max())
+
+    assert below_half(None) > 0.8
+    assert below_half("sqrt") < below_half(None)
+    assert below_half("rank") == pytest.approx(0.5, abs=0.05)
+
+
+def test_raw_heights_survive_scaling(uneven_groups):
+    """y_coords stays in the metric's units, so rescaling is repeatable."""
+    dens = uneven_groups()
+    den = dens[1]
+    before = den.y_coords.copy()
+
+    fig, ax = plt.subplots()
+    GroupDendrogram(dens, method="average").draw(ax, height_scale="shared")
+    assert np.array_equal(den.y_coords, before)
+    assert den.max_height == pytest.approx(before.max())
+
+
+def test_singleton_group_draws_as_a_stub_under_a_shared_scale():
+    """One row never merges, so its height is honestly zero."""
+    rng = np.random.default_rng(4)
+    dens = [
+        Dendrogram(rng.standard_normal((5, 4))),
+        Dendrogram(rng.standard_normal((1, 4))),
+    ]
+    fig, ax = plt.subplots()
+    GroupDendrogram(dens).draw(ax, height_scale="shared")
+
+    singleton = dens[1]
+    assert singleton.max_height == 0.0
+    assert np.all(singleton._render_y_coords == 0.0)
+
+
+def test_height_transform_needs_a_real_scale(uneven_groups):
+    gd = GroupDendrogram(uneven_groups(), method="average")
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError, match="height_transform needs height_scale"):
+        gd.draw(ax, height_transform="sqrt")
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"height_scale": "nope"}, "Unknown height_scale"),
+        ({"height_scale": "shared", "height_transform": "nope"}, "Unknown height_"),
+    ],
+)
+def test_height_options_are_validated(uneven_groups, kwargs, match):
+    gd = GroupDendrogram(uneven_groups(), method="average")
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError, match=match):
+        gd.draw(ax, **kwargs)
+
+
+def test_height_scale_reaches_a_plain_dendrogram():
+    """The standalone case is distorted by minmax too, so it takes the knob."""
+    board_data = np.random.default_rng(6).standard_normal((12, 5))
+    den = Dendrogram(board_data, method="ward")
+
+    fig, ax = plt.subplots()
+    den.draw(ax, height_scale="minmax")
+    assert den._render_y_coords[den.y_coords > 0].min() == pytest.approx(0.2)
+
+    fig, ax = plt.subplots()
+    den.draw(ax, height_scale="group")
+    drawn = den._render_y_coords[den.y_coords > 0]
+    assert drawn.min() == pytest.approx(
+        den.y_coords[den.y_coords > 0].min() / den.max_height
+    )
+    assert drawn.max() == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("scale", ["minmax", "group", "shared"])
+def test_add_dendrogram_passes_the_height_options_through(scale):
+    import marsilea as ma
+
+    rng = np.random.default_rng(8)
+    board = ma.Heatmap(rng.standard_normal((20, 6)))
+    board.group_rows(["a"] * 6 + ["b"] * 8 + ["c"] * 6)
+    board.add_dendrogram("left", height_scale=scale, method="ward")
+    board.render()
+
+    gd = board.get_deform().get_row_dendrogram()
+    assert gd.divider == pytest.approx(1.323 if scale == "minmax" else 1.0)

--- a/tests/test_dendrogram.py
+++ b/tests/test_dendrogram.py
@@ -176,7 +176,6 @@ def test_identical_group_centroids_can_be_drawn():
     GroupDendrogram(dens).draw(ax)
 
 
-@pytest.mark.xfail(reason="scipy's dendrogram() recurses per tree level", strict=True)
 def test_large_dendrogram_does_not_blow_the_stack():
     """Single linkage chains, so tree depth grows with the leaf count."""
     data = np.random.default_rng(3).standard_normal((3000, 10))

--- a/tests/test_dendrogram.py
+++ b/tests/test_dendrogram.py
@@ -184,7 +184,6 @@ def test_large_dendrogram_does_not_blow_the_stack():
     assert Dendrogram(data).n_leaves == 3000
 
 
-@pytest.mark.xfail(reason="singleton groups never set .Z", strict=True)
 def test_linkage_readable_with_a_singleton_group():
     import marsilea as ma
 

--- a/tests/test_dendrogram.py
+++ b/tests/test_dendrogram.py
@@ -66,3 +66,134 @@ def test_group_dendrogram():
     gd = GroupDendrogram([d1, d2, d3])
     assert gd.n == 3
     assert len(gd.dens) == 3
+
+
+# --- Geometry ---
+#
+# GroupDendrogram.draw() was never exercised before. These pin the drawn
+# coordinates so the height-scaling rewrite cannot move the default output.
+
+
+@pytest.fixture
+def group_den():
+    rng = np.random.default_rng(0)
+    dens = [
+        Dendrogram(rng.standard_normal((n, 4)), method="average") for n in (5, 3, 6)
+    ]
+    return GroupDendrogram(dens, method="average")
+
+
+def test_group_dendrogram_draw_golden(group_den):
+    """Default output, captured before the refactor."""
+    fig, ax = plt.subplots()
+    group_den.draw(ax, spacing=0.05)
+
+    assert group_den.den_ylim == pytest.approx(1.26)
+    assert group_den.divider == pytest.approx(1.323)
+    assert ax.get_ylim()[1] == pytest.approx(1.70667)
+    assert ax.get_xlim()[1] == pytest.approx(31.111111111111)
+
+    assert np.allclose(
+        group_den._render_x_coords,
+        [
+            [10.430555555556, 10.430555555556, 22.736111111111, 22.736111111111],
+            [2.5, 2.5, 16.583333333333, 16.583333333333],
+        ],
+    )
+    assert np.allclose(
+        group_den._render_y_coords,
+        [[1.323, 1.3734, 1.3734, 1.323], [1.323, 1.6254, 1.6254, 1.3734]],
+    )
+
+
+def test_every_group_apex_is_pinned_to_the_same_height(group_den):
+    """Documents the imbalance: per-group min-max erases real spread.
+
+    Each base dendrogram is normalized against its own range, so a tight group
+    and a diffuse one both top out at 1.2. Kept as the contrast case for the
+    shared height scale.
+    """
+    fig, ax = plt.subplots()
+    group_den.draw(ax)
+    assert [d.render_root[1] for d in group_den.dens] == pytest.approx([1.2, 1.2, 1.2])
+
+
+@pytest.mark.parametrize("orient", ["top", "bottom", "left", "right"])
+def test_group_dendrogram_draw_orients(group_den, orient):
+    fig, ax = plt.subplots()
+    group_den.draw(ax, orient=orient)
+    assert np.isfinite(ax.get_xlim()).all()
+    assert np.isfinite(ax.get_ylim()).all()
+    assert len(ax.collections) > 0
+
+
+def test_meta_x_is_piecewise_linear_over_the_leaf_skeleton(group_den):
+    """The meta leaves sit over the base roots; internal nodes interpolate.
+
+    This is what keeps the dendrogram aligned with the split heatmap chunks.
+    """
+    fig, ax = plt.subplots()
+    group_den.draw(ax, spacing=0.05)
+
+    skeleton = 1.0 + 2.0 * np.arange(group_den.n_leaves)
+    skeleton_x = [d.render_root[0] for d in group_den.dens]
+    assert np.allclose(
+        group_den._render_x_coords,
+        np.interp(group_den.x_coords, skeleton, skeleton_x),
+    )
+
+
+def test_base_roots_stay_inside_their_own_slot(group_den):
+    """Each base dendrogram must stay over its own heatmap chunk."""
+    fig, ax = plt.subplots()
+    group_den.draw(ax, spacing=0.05)
+    for den in group_den.dens:
+        lo, hi = den._render_xlim
+        assert lo <= den.render_root[0] <= hi
+
+
+# --- Degenerate inputs ---
+
+
+@pytest.mark.xfail(reason="interval == 0 divides by zero -> NaN ylim", strict=True)
+def test_equal_merge_heights_do_not_produce_nan():
+    """All merge heights equal makes the min-max interval zero."""
+    data = np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [1.0, 1.0]])
+    den = Dendrogram(data, method="average")
+    assert not np.isnan(den.y_coords).any()
+    assert np.isfinite(den.max_dependent_coord)
+
+
+@pytest.mark.xfail(reason="zero-height merge breaks the y==0 leaf mask", strict=True)
+def test_identical_group_centroids_can_be_drawn():
+    """Two groups with the same centroid merge at height zero."""
+    rng = np.random.default_rng(7)
+    chunk = rng.standard_normal((5, 4))
+    dens = [
+        Dendrogram(chunk),
+        Dendrogram(chunk.copy()),
+        Dendrogram(rng.standard_normal((5, 4))),
+    ]
+    fig, ax = plt.subplots()
+    GroupDendrogram(dens).draw(ax)
+
+
+@pytest.mark.xfail(reason="scipy's dendrogram() recurses per tree level", strict=True)
+def test_large_dendrogram_does_not_blow_the_stack():
+    """Single linkage chains, so tree depth grows with the leaf count."""
+    data = np.random.default_rng(3).standard_normal((3000, 10))
+    assert Dendrogram(data).n_leaves == 3000
+
+
+@pytest.mark.xfail(reason="singleton groups never set .Z", strict=True)
+def test_linkage_readable_with_a_singleton_group():
+    import marsilea as ma
+
+    board = ma.Heatmap(np.random.default_rng(5).standard_normal((6, 5)))
+    board.group_rows(["a", "a", "a", "a", "a", "b"])
+    board.add_dendrogram("left")
+    board.render()
+
+    linkages = board.get_row_linkage()
+    assert set(linkages) == {"a", "b"}
+    assert linkages["b"] is None

--- a/tests/test_dendrogram.py
+++ b/tests/test_dendrogram.py
@@ -356,3 +356,35 @@ def test_add_dendrogram_passes_the_height_options_through(scale):
 
     gd = board.get_deform().get_row_dendrogram()
     assert gd.divider == pytest.approx(1.323 if scale == "minmax" else 1.0)
+
+
+def test_height_scale_applies_without_control_ax():
+    """The height options must not depend on who owns the axes."""
+    data = np.random.default_rng(6).standard_normal((12, 5))
+    den = Dendrogram(data, method="ward")
+
+    fig, ax = plt.subplots()
+    den.draw(ax, control_ax=False, height_scale="group")
+    assert den._render_y_coords.max() == pytest.approx(1.0)
+
+    fig, ax = plt.subplots()
+    den.draw(ax, control_ax=False, height_scale="minmax")
+    assert den._render_y_coords.max() == pytest.approx(1.2)
+
+
+def test_group_scaling_survives_the_base_draw(uneven_groups):
+    """Drawing a base must not undo the scale its group just gave it."""
+    gd = GroupDendrogram(uneven_groups(), method="average")
+    fig, ax = plt.subplots()
+    gd.draw(ax, height_scale="shared")
+
+    tallest = max(d.max_height for d in gd.dens)
+    for den in gd.dens:
+        assert den._render_y_coords.max() == pytest.approx(den.max_height / tallest)
+
+
+def test_wrong_number_of_spacings_is_rejected(uneven_groups):
+    gd = GroupDendrogram(uneven_groups(), method="average")
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError, match="expected 2, one for each gap"):
+        gd.draw(ax, spacing=[0.01, 0.01, 0.01])


### PR DESCRIPTION
Two things prompted this: the dendrogram computing path was hard to follow, and grouped dendrograms with a meta tree often look unbalanced — dense at the bottom, sparse and disproportionately tall at the top.

Profiling first, because it changes what "efficiency" means here. On an 800×200 heatmap with 2 dendrograms and 7 side plots, `_deform` is **0.5%** of render time and `dendrogram.py` **0.6%**; matplotlib artist construction is 96.8%. `Deformation` is not a hotspot and this PR claims no speedup. `_compute_linkage` is the only real algorithmic cost and it is already memoized once per axis with a fastcluster path.

What profiling did turn up was four crashes.

## Crashes fixed

All four reproduce on `main` today:

| Repro | Failure |
|---|---|
| `Heatmap([[0,0,0],[0,0,0],[0,0,0],[1,1,1]]).add_dendrogram("left").render()` | `ValueError: Axis limits cannot be NaN or Inf` — the min-max interval is zero when a block of rows is identical |
| `Dendrogram(rng.random((2500, 10)))` | `RecursionError` — scipy recurses once per tree level and single linkage chains, so the default limit runs out at ~2500 leaves. Measured depth is ~0.65 frames per leaf |
| `GroupDendrogram` over two groups with the same centroid, then `.draw()` | `KeyError` — leaf positions were found by masking for zero height, but a zero-height *merge* is not a leaf |
| `group_rows` producing a one-row group, then `get_row_linkage()` | `AttributeError: no attribute 'Z'` — the singleton branch never set it |

The leaf positions now come from the structure (scipy places leaf *i* at `icoord` `5 + 10i`) rather than from a value mask. With a correct skeleton the 25-line hand-rolled piecewise-linear x-remap underneath is exactly `np.interp`, verified identical to 1e-11.

Three smaller ones in the same path: an ndarray of per-gap spacings silently degraded to the scalar branch (`np.ndarray` is not a `typing.Sequence`) and overcounted the total; spacing summing past 1 divided by zero instead of raising the way `layout._split` does; the divider line mixed model x at one end with render x at the other.

## Deformation

Every operation was a permutation followed by slicing at chunk offsets, but grouping, splitting, the leaf order inside each chunk and the order of the chunks were applied as four separate passes over progressively more nested lists. Hence `reorder_by_col` needing four levels of `ndim` branching plus a `split="2d"/"1d"` flag, and the reorder pass mutating the caller's list in place.

They compose. Resolving them once into a flat index plus chunk bounds makes deforming anything a take along the last axis followed by slices. `transform_row` and `transform_col` become the same function — `transform_row` was already transposing in and out, which is what `axis=-1` means.

Also: state moved off class attributes (including two mutable dicts, with no `__init__` at all) into one object per axis, and the ten `row_*`/`col_*` method pairs collapsed onto single axis-parameterized implementations behind the same public names.

`set_row_chunk_order`/`set_col_chunk_order` are fixed as a side effect — the ratios honoured the chunk order but the data pass returned early unless clustering was on, so the axis widths moved and the data did not.

`split_by_row`, `split_by_col`, `split_cross`, `reorder_by_row` and `reorder_by_col` were never meant to be public but autodoc published them, so they stay as deprecated shims for one minor.

## Visual balance

The cause is measurable. Merge heights were min-max stretched into `[0.2, 1.2]` **in the constructor, per dendrogram, overwriting the values scipy computed**. Every group therefore drew exactly as tall as every other one: on one fixture a group whose rows merge at 0.06 and a group that merges at 9.51 both reached the same apex, so a tight cluster looked as deep as a diffuse one and the meta dendrogram sat on a flat plateau of equal-length stubs.

Keeping the raw heights and moving the scaling to whoever owns the drawing is what makes a scale shared *across* groups possible at all. Two orthogonal knobs on `add_dendrogram`:

- `height_scale` — `"minmax"` (unchanged default) | `"group"` | `"shared"`. `"shared"` measures every group against the tallest merge anywhere, so the drawn apex ratio equals the real distance ratio and a tight group finally draws short.
- `height_transform` — `None` | `"sqrt"` | `"log"` | `"rank"` | callable. For bottom-heavy trees, where merges bunch up near the leaves and leave the top empty. On 60 rows with `method="ward"`, the fraction of merges below half height goes 0.85 → 0.47 under `sqrt`, and to 0.5 by construction under `rank`. Opt-in, because it makes the default `single` linkage *worse* and trades away readable distances. No transform may reorder two merges; that is asserted.

Under a real scale `meta_ratio` also becomes exact. It was off by 8/7, because the meta carried the same 0.2 floor as the bases and its normalization was commented out. The dead band of parallel stubs between the base apexes and the meta's first merge drops from 10.2% of the axis to whatever the groups' actual similarity justifies.

## Compatibility

The default stays `"minmax"`, so this is opt-in and no shipped figure moves. Nine rendered configurations — grouped, cut, cross-split, meta-only, base-only, with side plots, singleton group — are **pixel-identical to `main`**.

Two API notes for the changelog: `Dendrogram.y_coords` is now scipy's raw `dcoord` rather than pre-normalized (use `_render_y_coords` for drawn coordinates, or the new `max_height`), and `GroupDendrogram.divider`/`den_ylim` are filled in by `draw()` rather than `__init__`, since they depend on the scale asked for.

## Verification

The existing deform tests only asserted that no elements were lost, so they passed just as happily when rows came out in the wrong order. The first commit adds the safety net before anything else moves:

- the exact row and column permutation for all 16 cluster/split combinations under both `cut_*` and `group_*` splitting
- the main canvas and the side plots agreeing on that order — untested before, and the whole point of the module
- ratios matching chunk sizes, transform idempotence, no input mutation, clustering running exactly once, no shared class state, `deepcopy` independence
- `GroupDendrogram.draw()` geometry, which had no coverage at all, plus the x-interpolation and slot-containment invariants that keep the dendrogram aligned with its heatmap chunks
- the four crashes as `xfail(strict)`, each flipped by the commit that fixes it

509 tests pass. Every shipped example that draws a dendrogram still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)