### PR TITLE
fix(docs): make gallery images reproducible across builds

### DIFF
--- a/docs/examples/Basics/plot_adv_heatmap.py
+++ b/docs/examples/Basics/plot_adv_heatmap.py
@@ -10,7 +10,7 @@ import numpy as np
 import marsilea as ma
 
 data = np.random.randint(0, 10, (10, 10))
-groups = np.random.choice(["A", "B", "C"], 10)
+groups = np.repeat(["A", "B", "C"], [4, 3, 3])
 
 # %%
 

--- a/docs/examples/Plotters/plot_chunk.py
+++ b/docs/examples/Plotters/plot_chunk.py
@@ -13,8 +13,6 @@ from marsilea.plotter import Chunk
 matrix = np.random.randn(20, 20)
 h = ma.Heatmap(matrix)
 chunk = ["C1", "C2", "C3", "C4"]
-# Fixed group sizes: drawing the labels leaves a 1-in-80 chance that one chunk
-# never comes up, and `order` below then asks for a group that is not in the data.
 labels = np.repeat(chunk, [6, 5, 5, 4])
 h.group_rows(labels, order=chunk)
 h.add_right(Chunk(chunk, bordercolor="gray"), pad=0.1)

--- a/docs/examples/Plotters/plot_chunk.py
+++ b/docs/examples/Plotters/plot_chunk.py
@@ -13,7 +13,9 @@ from marsilea.plotter import Chunk
 matrix = np.random.randn(20, 20)
 h = ma.Heatmap(matrix)
 chunk = ["C1", "C2", "C3", "C4"]
-labels = np.random.choice(chunk, size=20)
+# Fixed group sizes: drawing the labels leaves a 1-in-80 chance that one chunk
+# never comes up, and `order` below then asks for a group that is not in the data.
+labels = np.repeat(chunk, [6, 5, 5, 4])
 h.group_rows(labels, order=chunk)
 h.add_right(Chunk(chunk, bordercolor="gray"), pad=0.1)
 h.add_dendrogram("left")

--- a/docs/examples/Plotters/plot_fixed_chunk.py
+++ b/docs/examples/Plotters/plot_fixed_chunk.py
@@ -14,8 +14,6 @@ matrix = np.random.randn(20, 20)
 
 h = ma.Heatmap(matrix)
 chunk = ["C1", "C2-1", "C2-2", "C4"]
-# Fixed group sizes: drawing the labels leaves a 1-in-80 chance that one chunk
-# never comes up, and `order` below then asks for a group that is not in the data.
 labels = np.repeat(chunk, [6, 5, 5, 4])
 h.group_rows(labels, order=chunk)
 h.add_right(FixedChunk(chunk, bordercolor="gray"), pad=0.1)

--- a/docs/examples/Plotters/plot_fixed_chunk.py
+++ b/docs/examples/Plotters/plot_fixed_chunk.py
@@ -14,7 +14,9 @@ matrix = np.random.randn(20, 20)
 
 h = ma.Heatmap(matrix)
 chunk = ["C1", "C2-1", "C2-2", "C4"]
-labels = np.random.choice(chunk, size=20)
+# Fixed group sizes: drawing the labels leaves a 1-in-80 chance that one chunk
+# never comes up, and `order` below then asks for a group that is not in the data.
+labels = np.repeat(chunk, [6, 5, 5, 4])
 h.group_rows(labels, order=chunk)
 h.add_right(FixedChunk(chunk, bordercolor="gray"), pad=0.1)
 h.add_right(

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,6 +18,7 @@ import shutil
 from datetime import datetime
 from pathlib import Path
 
+import numpy as np
 from mpl_fontkit.core import get_font_install_path
 from sphinx_gallery.sorting import FileNameSortKey, ExplicitOrder
 from sphinx_gallery.scrapers import matplotlib_scraper
@@ -49,7 +50,26 @@ def _seed_asset_caches():
             shutil.copyfile(src, fonts / src.name)
 
 
+def _seed_seaborn_bootstrap():
+    """Make seaborn's error-bar bootstrap reproducible.
+
+    ``Bar`` and ``Point`` wrap ``barplot``/``pointplot``, which pass an explicit
+    ``seed=None`` down to ``seaborn.algorithms.bootstrap``. That draws from a
+    fresh ``default_rng()``, so seeding ``np.random`` never reaches it and the
+    confidence intervals moved on every build.
+    """
+    from seaborn import _statistics  # the only module that binds the name
+
+    original = _statistics.bootstrap
+
+    def bootstrap(*args, seed=None, **kwargs):
+        return original(*args, seed=0 if seed is None else seed, **kwargs)
+
+    _statistics.bootstrap = bootstrap
+
+
 _seed_asset_caches()
+_seed_seaborn_bootstrap()
 
 # -- Project information -----------------------------------------------------
 
@@ -128,6 +148,16 @@ def matplotlib_tight_scraper(*args, **kwargs):
     )
 
 
+def reset_random_seed(gallery_conf, fname):
+    """Seed numpy before every gallery script.
+
+    ``plot_pre_code`` above does this for docstring ``.. plot::`` blocks. Gallery
+    scripts got no seed, so each build redrew every random example and the image
+    diffs buried any real visual regression.
+    """
+    np.random.seed(0)
+
+
 intersphinx_mapping = {
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "seaborn": ("https://seaborn.pydata.org/", None),
@@ -144,6 +174,8 @@ sphinx_gallery_conf = {
     "within_subsection_order": FileNameSortKey,  # Order by file name
     "image_srcset": ["2x"],
     "image_scrapers": (matplotlib_tight_scraper,),
+    # ("matplotlib", "seaborn") is the sphinx-gallery default; keep it.
+    "reset_modules": ("matplotlib", "seaborn", reset_random_seed),
     "subsection_order": ExplicitOrder(
         [
             "../examples/Basics",


### PR DESCRIPTION
Every docs build redrew the 36 sphinx-gallery scripts that call `np.random.*`: unlike docstring `.. plot::` blocks, which `conf.py` seeds via `plot_pre_code`, gallery scripts got no seed. Two consequences — image diffs were noise on every build, so a real visual regression would be invisible, and randomness-induced correctness bugs stayed hidden until a build rolled badly. One already did, in `plot_adv_heatmap` (3318510).

## What changed

**Seed centrally, not in 36 files.** A `reset_modules` entry in `sphinx_gallery_conf` runs before *each* script, so a partial rebuild produces the same images as a clean one. The two sphinx-gallery defaults (`matplotlib`, `seaborn`) are kept.

**Seeding numpy was not enough.** 17 images still moved between builds, including docstring `.. plot::` images that `plot_pre_code` already seeds (`marsilea-plotter-Bar-*`, `intro-5`). `Bar` and `Point` wrap seaborn `barplot`/`pointplot`, which pass an *explicit* `seed=None` into `seaborn.algorithms.bootstrap`; that builds a fresh `default_rng()`, which `np.random.seed` cannot reach, so the error-bar confidence intervals were redrawn every time. `_seed_seaborn_bootstrap()` substitutes 0 for that None. Isolated it first: two `Bar` renders in one process hash identically once the seed is forced, and differ otherwise.

**Three scripts drew their own groups and then demanded an order.** `np.random.choice` over the label set followed by `order=` leaves a chance per build that one label never comes up, and `group_rows` is then asked for a group that is not in the data (`KeyError` in `reorder_index`). All three now use fixed group sizes, which the seed cannot regress if numpy ever changes its RNG stream:

| script | labels | failure rate |
| --- | --- | --- |
| `Basics/plot_adv_heatmap.py` | 3 over 10 rows | 5.2% |
| `Plotters/plot_chunk.py` | 4 over 20 rows | 1.27% |
| `Plotters/plot_fixed_chunk.py` | 4 over 20 rows | 1.27% |

`plot_adv_heatmap` is the one that took down an RTD build. It was fixed in 3318510, but that commit sits on `feature/statannotations-integration` and never reached `main`, so the bug is still live here; this PR applies the same fix so the two branches converge.

## Audit

Checked every unseeded script for correctness — not just appearance — depending on the draw. Nothing else: `Range` treats its pairs as unordered, `SeqLogo`'s `randint(1, 10)` is always positive, `Area` adds 1, the `order=` in `plot_legends` names plots rather than categories, and the dendrogram examples cut on positional indices rather than labels.

## Verification

Two consecutive `uv run task doc-clean-build` runs on Python 3.12 — 57 gallery scripts re-executed in each, exit 0, no warnings — produce **336/336 byte-identical images** (`diff -rq` clean). 17 differed before the seaborn fix.

## For the reviewer

- `_seed_seaborn_bootstrap` monkeypatches `seaborn._statistics.bootstrap`, the only module that binds the name. Contained to the docs build, and it is what makes the `Bar`/`Point` images stable; a docs-side fix covers the `.. plot::` images in `src/` docstrings too, which per-example `seed=` kwargs would not.
- The examples keep bare `np.random.*` and carry no explanatory comments; determinism comes from the build, and the reasoning lives in the commit messages rather than in the rendered gallery. If a script ever needs to be reproducible standalone, give that one an explicit `default_rng(0)`.
- Unrelated and pre-existing: the build fails on **Python 3.14** in `plot_oncoprint.py` at `op /= h` → `deepcopy(board.layout)` → `TypeError: cannot pickle 'itertools.count' object` (`src/marsilea/base.py:35`). Fine on 3.12; #99 just widened CI to 3.14, so it needs its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
