### PR TITLE
fix: stop deep-copying live matplotlib artists when composing boards

### DIFF
--- a/src/marsilea/layout.py
+++ b/src/marsilea/layout.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass
 from numbers import Number
 from typing import List, Dict, Literal
@@ -92,6 +93,25 @@ def get_axes_rect(rect, figsize):
     return cx / fig_w, cy / fig_h, cw / fig_w, ch / fig_h
 
 
+# Attributes that hold live matplotlib artists (Figure/Axes).
+_LIVE_ARTIST_ATTRS = ("figure", "ax")
+
+
+def _deepcopy_drop_artists(self, memo):
+    """__deepcopy__ that drops references to live matplotlib artists.
+
+    A copied layout is always re-frozen onto its own figure, so the
+    source's figure and axes are stale for the copy.  They are also not
+    deep-copyable on Python 3.14+: matplotlib's ``category.UnitData``
+    holds an ``itertools.count``, which lost pickle support there.
+    """
+    new = self.__class__.__new__(self.__class__)
+    memo[id(self)] = new
+    for k, v in vars(self).items():
+        setattr(new, k, None if k in _LIVE_ARTIST_ATTRS else deepcopy(v, memo))
+    return new
+
+
 class BaseCell:
     name: str
     side: str
@@ -106,6 +126,8 @@ class BaseCell:
     v_ratios: np.ndarray = None
 
     is_canvas: bool = True
+
+    __deepcopy__ = _deepcopy_drop_artists
 
     def set_ax(self, ax):
         self.ax = ax
@@ -228,6 +250,8 @@ class Margin:
 
 class _MarginMixin:
     margin = Margin(0, 0, 0, 0)
+
+    __deepcopy__ = _deepcopy_drop_artists
 
     def set_margin(self, margin):
         if isinstance(margin, Number):
@@ -674,6 +698,8 @@ class _LegendAxes:
     size: float
     pad: float
     ax = None
+
+    __deepcopy__ = _deepcopy_drop_artists
 
     def get_length(self):
         return self.size + self.pad

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -25,6 +25,25 @@ def test_composite_vertical(rng):
     comp.render()
 
 
+def test_composite_after_render(rng):
+    """Composing already-rendered boards must not deep-copy live figure/axes.
+
+    The Violin gives the axes a categorical unit, whose matplotlib
+    ``UnitData`` holds an ``itertools.count`` -- not copyable on Python
+    3.14+, where it raised ``cannot pickle 'itertools.count' object``.
+    """
+    h1 = _make_heatmap(rng)
+    h1.add_top(mp.Violin(rng.standard_normal((6, 4))))
+    h2 = _make_heatmap(rng)
+    h1.render()
+    h2.render()
+    comp = h1 / h2
+    comp.render()
+    # the copy got its own figure, the sources kept theirs
+    assert comp.figure is not h1.figure
+    assert h1.figure is not None
+
+
 def test_composite_mixed(rng):
     h1 = _make_heatmap(rng)
     h2 = _make_heatmap(rng)


### PR DESCRIPTION
## What

Composing an already-rendered board with `/` or `+` crashed on Python 3.14:

```
File "src/marsilea/base.py", line 35, in _copy_board -> new.layout = deepcopy(board.layout)
TypeError: cannot pickle 'itertools.count' object
```

This took down `docs/examples/Gallery/plot_oncoprint.py` at `op /= h`, which made `task doc-build` exit 2 (sphinx_gallery's `summarize_failing_examples`) on any interpreter resolving to 3.14. CI was widened to 3.11–3.14 in dd0ef82, so it is in-matrix.

## Why

`_copy_board` deep-copies `board.layout`. After a render, the layout holds a live `Figure` (`layout.figure`) and the `Axes` of every cell (`cell.ax`). If any axis carries categorical units, that graph reaches matplotlib's `category.UnitData`, which holds an `itertools.count` — and Python 3.14 removed pickle/`__reduce__` support from itertools iterators, so `deepcopy(itertools.count())` now raises where 3.12 returned a copy.

The counter is matplotlib's, not the one in `src/oncoprinter/core.py` — that `count(0, 1)` is consumed by `zip` and never stored.

Object-graph walk from `board.layout` confirms `figure` and `ax` are the only attribute names that ever hold an artist:

```
layout.figure                                  -> Figure
layout.cells['<name>'].ax                      -> Axes
layout.cells['mutation_count'].attach.ax       -> Axes
```

## How

A shared `__deepcopy__` on `BaseCell`, `_MarginMixin` (covers `CrossLayout`, `CompositeCrossLayout`, `StackCrossLayout`) and `_LegendAxes` that nulls `figure`/`ax` instead of copying them.

Dropping them is also semantically right, independent of the Python version: a copied layout is always re-frozen onto its own figure, so the source's figure and axes are stale for the copy. The old behaviour silently built detached duplicate axes and paid to deep-copy an entire figure.

No matplotlib-side workaround (e.g. patching `UnitData.__deepcopy__`) — copying a live figure here was wrong regardless.

## Why the existing tests missed it

`test_composite_*` compose *unrendered* float heatmaps: no live figure, no categorical axis. Two conditions are both needed to reproduce — render before composing, and an axis with categorical units.

The new `test_composite_after_render` adds a `Violin` (seaborn plotters pin a categorical axis), renders both boards, then composes. Verified it fails with the exact `TypeError` when the fix is reverted.

## Verification

- `plot_oncoprint.py` runs clean on 3.14; `uv run --python 3.14 task doc-clean-build` → `build succeeded`
- `520 passed, 6 xfailed` on Python 3.11, 3.12 and 3.14
- New test fails without the fix, passes with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)