### PR TITLE
docs: correct the paper citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If you use Marsilea in your research, please cite the following:
 > 
 > Yimin Zheng, Zhihang Zheng, André F. Rendeiro & Edwin Cheung
 > 
-> _Genome Biology_ 2025 Jan 06. DOI: [10.1186/s13059-017-1382-0](https://doi.org/10.1186/s13059-024-03469-3)
+> _Genome Biology_ 2025 Jan 06. DOI: [10.1186/s13059-024-03469-3](https://doi.org/10.1186/s13059-024-03469-3)
 
 ## Get helps
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,8 +28,8 @@ together like logo.
             :shadow: none
 
             If you use Marsilea in your research, please cite:
-            `Marsilea: an intuitive generalized framework for composable visualizations <https://doi.org/10.1186/s13059-024-03469-3>`_
-            — *Genome Biology*, 2024
+            `Marsilea: an intuitive generalized paradigm for composable visualizations <https://doi.org/10.1186/s13059-024-03469-3>`_
+            — *Genome Biology*, 2025
 
         .. card :: Related Projects
             :shadow: none


### PR DESCRIPTION
The Marsilea paper was published in **2025**, not 2024. Verified against Crossref:

```
title    : Marsilea: an intuitive generalized paradigm for composable visualizations
journal  : Genome Biology
published: 2025-01-06        volume 26, issue 1, article 5
```

The DOI slug reads `s13059-**024**-03469-3` because that is when it was registered, which is presumably where the 2024 came from.

Three one-line fixes:

- `docs/source/index.rst` — year 2024 → 2025
- `docs/source/index.rst` — title `framework` → `paradigm`, matching what was published
- `README.md` — the citation printed `10.1186/s13059-017-1382-0` as the link text (an unrelated Genome Biology paper) while the href underneath was already correct

The README already said "2025 Jan 06", so the year was only wrong on the docs index. `CITATION.cff` is untouched: its `10.1101/2024.02.14.580236` is the bioRxiv preprint and genuinely is 2024.

Docs-only, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)