### PR TITLE
fix: render nested StackBoard boards in place

### DIFF
--- a/docs/source/tutorial/stack.rst
+++ b/docs/source/tutorial/stack.rst
@@ -5,9 +5,11 @@ Stack Multiple Cross-layouts
 place multiple cross-layouts. Unlike :class:`CompositeBoard <marsilea.base.CompositeBoard>`,
 it can also stack itself.
 
-.. warning::
-    The :class:`StackBoard <marsilea.base.StackBoard>` is still considered experimental.
-    There might be some issues with the rendering.
+.. note::
+    :meth:`get_ax <marsilea.base.StackBoard.get_ax>` and
+    :meth:`get_main_ax <marsilea.base.StackBoard.get_main_ax>` only reach the boards
+    stacked directly in a :class:`StackBoard <marsilea.base.StackBoard>`, not the ones
+    inside a nested stack.
 
 Let's create three different heatmaps for demonstration:
 
@@ -87,7 +89,8 @@ We can stack them in different ways, notice that the alignment is relative to th
 Grid of heatmaps?
 -----------------
 
-You can also stack multiple heatmaps in a grid layout. For example, let's stack
+A :class:`StackBoard <marsilea.base.StackBoard>` can stack other stacks, so a row of
+heatmaps stacked vertically gives you a grid:
 
 .. plot::
     :context: close-figs

--- a/docs/source/tutorial/stack.rst
+++ b/docs/source/tutorial/stack.rst
@@ -3,13 +3,16 @@ Stack Multiple Cross-layouts
 
 :class:`StackBoard <marsilea.base.StackBoard>` offers an alternative way to
 place multiple cross-layouts. Unlike :class:`CompositeBoard <marsilea.base.CompositeBoard>`,
-it can also stack itself.
+it can stack itself, and it can stack a
+:class:`CompositeBoard <marsilea.base.CompositeBoard>` too. The reverse does not
+work: a :class:`StackBoard <marsilea.base.StackBoard>` cannot be appended to a
+:class:`CompositeBoard <marsilea.base.CompositeBoard>` with ``+`` or ``/``.
 
 .. note::
     :meth:`get_ax <marsilea.base.StackBoard.get_ax>` and
     :meth:`get_main_ax <marsilea.base.StackBoard.get_main_ax>` only reach the boards
     stacked directly in a :class:`StackBoard <marsilea.base.StackBoard>`, not the ones
-    inside a nested stack.
+    inside a nested stack or composite.
 
 Let's create three different heatmaps for demonstration:
 
@@ -104,3 +107,18 @@ heatmaps stacked vertically gives you a grid:
     >>> sb2 = ma.StackBoard([h3, h4], direction="horizontal", align="center")
     >>> final_sb = ma.StackBoard([sb1, sb2], direction="vertical", align="center")
     >>> final_sb.render()
+
+Stacking :class:`CompositeBoard <marsilea.base.CompositeBoard>` works the same way.
+The rows are flush here, since ``+`` leaves no space between the boards it joins,
+whereas a stack separates them by its `spacing`:
+
+.. plot::
+    :context: close-figs
+
+    >>> row1 = ma.Heatmap(data, cmap="Reds", height=1, width=1) + ma.Heatmap(
+    ...     data, cmap="Greens", height=1, width=1
+    ... )
+    >>> row2 = ma.Heatmap(data, cmap="Blues", height=1, width=1) + ma.Heatmap(
+    ...     data, cmap="Purples", height=1, width=1
+    ... )
+    >>> ma.StackBoard([row1, row2], direction="vertical", align="center").render()

--- a/src/marsilea/base.py
+++ b/src/marsilea/base.py
@@ -860,6 +860,15 @@ class _GroupBoard(LegendMaker):
         for board in self._board_list:
             board._freeze_flex_plots(figure)
 
+    def _freeze_legend(self, figure):
+        super()._freeze_legend(figure)
+        # With keep_legends=True a board draws its own legend, so its
+        # legend axes must be sized and registered before the tree is
+        # frozen: _draw needs the axes to exist, and the legend is a side
+        # cell, so the stack only leaves room for it if it is there first.
+        for board in self._board_list:
+            board._freeze_legend(figure)
+
     def remove_legends(self):
         super().remove_legends()
         # Keep the boards in step with the layout tree, whose legend

--- a/src/marsilea/base.py
+++ b/src/marsilea/base.py
@@ -23,42 +23,58 @@ from .plotter.mesh import MeshBase
 from .utils import pairwise, batched, get_plot_name, _check_side
 
 
-def _copy_board(board):
+# Attributes whose container must not be shared with the source board,
+# but whose contents are. Plotters are shared on purpose: a render does
+# not mutate them in a way the copy cares about, and copying one would
+# drag in the live matplotlib artists it keeps after a render (a Bar
+# plotter holds its BarContainer). The layout classes solve the same
+# problem one level down with their own __deepcopy__.
+_COPY_SHALLOW = (
+    "_user_legends",
+    "_legend_switch",
+    "_col_plan",
+    "_row_plan",
+    "_layer_plan",
+    "_row_den",
+    "_col_den",
+)
+
+
+def _copy_board(board, layout=None):
     """Shallow-copy a board but deep-copy layout and plan metadata.
 
-    Data arrays held by RenderPlan._data are large numpy arrays;
-    we keep references to them instead of copying.  Everything
-    that controls axes geometry and legend state is deep-copied so
-    the copy is independent of the original.
+    Everything that controls axes geometry and legend state is
+    deep-copied so the copy is independent of the original.
+
+    `layout` is passed when copying the boards held by a group board, so
+    each child is bound to the sub-layout that already lives in the
+    parent's copied layout tree. Deep-copying the tree and the children
+    separately leaves the children pointing at layouts that nothing
+    positions, and they then draw at the wrong place.
     """
     new = copy.copy(board)
-    new.layout = deepcopy(board.layout)
+    new.layout = deepcopy(board.layout) if layout is None else layout
     new._legend_grid_kws = deepcopy(board._legend_grid_kws)
     new._legend_draw_kws = deepcopy(board._legend_draw_kws)
-    new._user_legends = dict(board._user_legends)
-    new._draw_legend = board._draw_legend
+    for attr in _COPY_SHALLOW:
+        if hasattr(board, attr):
+            setattr(new, attr, copy.copy(getattr(board, attr)))
 
-    # WhiteBoard-specific attributes (not present on StackBoard/CompositeBoard)
-    if hasattr(board, "_legend_switch"):
-        new._legend_switch = dict(board._legend_switch)
-    if hasattr(board, "_col_plan"):
-        new._col_plan = list(board._col_plan)
-    if hasattr(board, "_row_plan"):
-        new._row_plan = list(board._row_plan)
-    if hasattr(board, "_layer_plan"):
-        new._layer_plan = list(board._layer_plan)
-
-    # StackBoard/CompositeBoard: deep-copy their nested board lists
-    if hasattr(board, "_board_list"):
-        new._board_list = list(board._board_list)
-
-    # ClusterBoard-specific attributes
+    # ClusterBoard-specific
     if hasattr(board, "_deform"):
         new._deform = deepcopy(board._deform)
-    if hasattr(board, "_row_den"):
-        new._row_den = list(board._row_den)
-    if hasattr(board, "_col_den"):
-        new._col_den = list(board._col_den)
+
+    # StackBoard/CompositeBoard hold other boards
+    if hasattr(board, "_board_list"):
+        sub_layouts = new.layout.layouts
+        if isinstance(sub_layouts, dict):  # CompositeCrossLayout keys by name
+            sub_layouts = list(sub_layouts.values())
+        new._board_list = [
+            _copy_board(child, layout=sub)
+            for child, sub in zip(board._board_list, sub_layouts, strict=True)
+        ]
+        if hasattr(board, "main_board"):
+            new.main_board = new._board_list[0]
 
     return new
 
@@ -733,16 +749,24 @@ class WhiteBoard(LegendMaker):
         """
         if figure is None:
             figure = plt.figure()
-        self.figure = figure
         self._freeze_legend(figure)
         self._freeze_flex_plots(figure)
 
         self.layout.freeze(figure=figure, scale=scale)
 
-        # render other plots
+        self._draw(figure)
+        return self
+
+    def _draw(self, figure):
+        """Draw on the axes of an already frozen layout.
+
+        Split out of :meth:`render` so a group board can freeze the whole
+        layout tree once and then only draw, instead of every child
+        re-freezing its own layout and re-creating its axes.
+        """
+        self.figure = figure
         self._render_plan()
         self._render_legend()
-        return self
 
     def save(self, fname, **kwargs):
         """Save the figure to a file
@@ -813,7 +837,77 @@ class ZeroHeight(WhiteBoard):
         )
 
 
-class CompositeBoard(LegendMaker):
+class _GroupBoard(LegendMaker):
+    """Shared behavior for boards that render a list of other boards.
+
+    A group board owns the whole layout tree: it freezes it once and then
+    asks every board in it to draw, instead of letting each child freeze
+    its own layout again.
+    """
+
+    figure: Figure = None
+    keep_legends: bool = False
+    _board_list: List
+
+    def new_board(self, board):
+        board = _copy_board(board)
+        if not self.keep_legends and isinstance(board, LegendMaker):
+            board.remove_legends()
+        return board
+
+    # To mimic the board API
+    def _freeze_flex_plots(self, figure):
+        for board in self._board_list:
+            board._freeze_flex_plots(figure)
+
+    def remove_legends(self):
+        super().remove_legends()
+        # Keep the boards in step with the layout tree, whose legend
+        # axes we just dropped
+        for board in self._board_list:
+            board.remove_legends()
+
+    def render(self, figure=None, scale=1):
+        if figure is None:
+            figure = plt.figure()
+        self._freeze_legend(figure)
+        self._freeze_flex_plots(figure)
+        self.layout.freeze(figure=figure, scale=scale)
+        self._draw(figure)
+        return self
+
+    def _draw(self, figure):
+        self.figure = figure
+        for board in self._board_list:
+            board._draw(figure)
+        self._render_legend()
+
+    def save(self, fname, **kwargs):
+        if self.figure is None:
+            self.render()
+        save_options = dict(bbox_inches="tight")
+        save_options.update(kwargs)
+        self.figure.savefig(fname, **save_options)
+        return self
+
+    def get_legends(self):
+        legends = {}
+        for m in self._board_list:
+            legends.update(m.get_legends())
+        return legends
+
+    def get_ax(self, board_name, ax_name):
+        return self.layout.get_ax(board_name, ax_name)
+
+    def get_main_ax(self, name):
+        return self.layout.get_main_ax(name)
+
+    def set_margin(self, margin):
+        self.layout.set_margin(margin)
+        return self
+
+
+class CompositeBoard(_GroupBoard):
     """Layout multiple canvas
 
     Parameters
@@ -831,7 +925,6 @@ class CompositeBoard(LegendMaker):
     """
 
     layout: CompositeCrossLayout = None
-    figure: Figure = None
 
     def __init__(
         self,
@@ -851,12 +944,6 @@ class CompositeBoard(LegendMaker):
         self._board_list = [self.main_board]
 
         super().__init__()
-
-    def new_board(self, board):
-        board = _copy_board(board)
-        if not self.keep_legends and isinstance(board, LegendMaker):
-            board.remove_legends()
-        return board
 
     def __add__(self, other):
         """Define behavior that horizontal appends two grid"""
@@ -878,60 +965,44 @@ class CompositeBoard(LegendMaker):
             self.layout.append(side, pad)
         return self
 
-    def render(self, figure=None, scale=1):
-        if figure is None:
-            figure = plt.figure()
-        self._freeze_legend(figure)
-        for board in self._board_list:
-            board._freeze_flex_plots(figure)
-        self.layout.freeze(figure=figure, scale=scale)
-        self.figure = figure
-        for board in self._board_list:
-            board.render(figure=self.figure)
 
-        self._render_legend()
-
-    def save(self, fname, **kwargs):
-        if self.figure is None:
-            self.render()
-        save_options = dict(bbox_inches="tight")
-        save_options.update(kwargs)
-        self.figure.savefig(fname, **save_options)
-
-    def get_legends(self):
-        legends = {}
-        for m in self._board_list:
-            legends.update(m.get_legends())
-        return legends
-
-    def get_ax(self, board_name, ax_name):
-        return self.layout.get_ax(board_name, ax_name)
-
-    def get_main_ax(self, name):
-        return self.layout.get_main_ax(name)
-
-    def set_margin(self, margin):
-        self.layout.set_margin(margin)
-
-
-class StackBoard(LegendMaker):
+class StackBoard(_GroupBoard):
     """Stack multiple boards
 
     Parameters
     ----------
     boards : list of :class:`WhiteBoard`, :class:`StackBoard`
+        The boards to stack, a :class:`StackBoard` may be stacked itself
+    direction : {"horizontal", "vertical"}, default: "horizontal"
+        Stack from left to right, or from top to bottom
+    align : {"center", "top", "bottom", "left", "right"}, default: "center"
+        How to align the boards on the other axis, relative to their
+        main canvas. Only "center", "top" and "bottom" are valid for
+        `direction="horizontal"`, and only "center", "left" and "right"
+        for `direction="vertical"`.
+    spacing : float, default: 0.2
+        The space between two boards in inches
+    margin : float, 4-tuple, default: 0
+        The margin space reserved around the whole canvas in inches
+    keep_legends : bool, default: False
+        Whether to keep the legends in each board.
+        If False, you can group all legends with `.add_legends()`
 
     """
 
+    layout: StackCrossLayout = None
+
     def __init__(
         self,
-        boards: List[WhiteBoard, StackBoard],
+        boards: List[WhiteBoard | StackBoard],
         direction="horizontal",
         align="center",
         spacing=0.2,
         margin=0,
         keep_legends=False,
     ):
+        if len(boards) == 0:
+            raise ValueError("Cannot stack an empty list of boards")
         self.keep_legends = keep_legends
         board_list = []
         layouts = []
@@ -946,54 +1017,6 @@ class StackBoard(LegendMaker):
 
         self._board_list = board_list
         super().__init__()
-
-    # To mimic the board API
-    def _freeze_flex_plots(self, figure):
-        for board in self._board_list:
-            board._freeze_flex_plots(figure)
-
-    def new_board(self, board):
-        board = _copy_board(board)
-        if not self.keep_legends and isinstance(board, LegendMaker):
-            board.remove_legends()
-        return board
-
-    def render(self, figure=None, scale=1):
-        if figure is None:
-            figure = plt.figure()
-        self._freeze_legend(figure)
-        for board in self._board_list:
-            board._freeze_flex_plots(figure)
-        self.layout.freeze(figure=figure, scale=scale)
-        self.figure = figure
-        for board in self._board_list:
-            board.render(figure=self.figure)
-
-        self._render_legend()
-        return self
-
-    def save(self, fname, **kwargs):
-        if self.figure is None:
-            self.render()
-        save_options = dict(bbox_inches="tight")
-        save_options.update(kwargs)
-        self.figure.savefig(fname, **save_options)
-        return self
-
-    def get_legends(self):
-        legends = {}
-        for m in self._board_list:
-            legends.update(m.get_legends())
-        return legends
-
-    def get_ax(self, board_name, ax_name):
-        return self.layout.get_ax(board_name, ax_name)
-
-    def get_main_ax(self, name):
-        return self.layout.get_main_ax(name)
-
-    def set_margin(self, margin):
-        self.layout.set_margin(margin)
 
 
 class ClusterBoard(WhiteBoard):
@@ -1539,29 +1562,19 @@ class ClusterBoard(WhiteBoard):
         """If column dendrogram is added"""
         return len(self._col_den) > 0
 
-    def render(self, figure=None, scale=1):
+    def _freeze_flex_plots(self, figure):
         if self._deform is None:
             raise ValueError("No layer is added to the plot")
-        if figure is None:
-            figure = plt.figure()
-        self.figure = figure
-        self._freeze_legend(figure)
-        self._freeze_flex_plots(figure)
-
-        # Make sure all axes is split
+        super()._freeze_flex_plots(figure)
+        # Make sure all axes is split before the layout is frozen
         self._setup_axes()
-        # Place axes
-        # if refreeze:
-        #     self.figure = self.layout.freeze(figure=figure, scale=scale)
-        # else:
-        #     self.figure = self.layout.figure
-        self.layout.freeze(figure=figure, scale=scale)
-        # render other plots
+
+    def _draw(self, figure):
+        self.figure = figure
         self._render_plan()
         # add row and col dendrogram
         self._render_dendrogram()
         self._render_legend()
-        return self
 
 
 class ZeroWidthCluster(ClusterBoard):

--- a/src/marsilea/layout.py
+++ b/src/marsilea/layout.py
@@ -718,8 +718,11 @@ class CompositeCrossLayout(_MarginMixin):
     """
 
     figure = None
+    # True when this layout is nested in another one, which then owns the
+    # figure size and tells us where to sit
+    is_composite = False
 
-    def __init__(self, main_layout, margin=0, align_main=True) -> None:
+    def __init__(self, main_layout, margin=0, align_main=True, name=None) -> None:
         self.main_layout = _reset_layout(main_layout)
         self.main_cell_height = self.main_layout.get_main_height()
         self.main_cell_width = self.main_layout.get_main_width()
@@ -733,6 +736,12 @@ class CompositeCrossLayout(_MarginMixin):
         self.layouts = {self.main_layout.main_cell.name: self.main_layout}
         self.set_margin(margin)
         self.align_main = align_main
+        if name is None:
+            name = uuid4().hex
+        self.name = name
+        self.figsize = None
+        # The main canvas anchor, set by a parent layout when nested
+        self.anchor = None
 
     def append(self, side, other):
         _check_side(side)
@@ -838,19 +847,43 @@ class CompositeCrossLayout(_MarginMixin):
         return fig_w, fig_h
 
     def get_main_anchor(self):
+        if self.anchor is not None:
+            return self.anchor
         x = self.get_side_size("left") + self.margin.left
         y = self.get_side_size("bottom") + self.margin.bottom
         return x, y
 
     def set_anchor(self, anchor):
-        self.main_layout.set_anchor(anchor)
+        # Where the main canvas goes; freeze places everything else
+        # relative to it
+        self.anchor = anchor
+
+    # Mimic the CrossLayout API, so this layout can be stacked
+    def set_figsize(self, figsize):
+        self.figsize = figsize
+
+    def get_main_width(self):
+        return self.main_cell_width
+
+    def get_main_height(self):
+        return self.main_cell_height
+
+    def remove_legend_ax(self):
+        self._legend_axes = None
+        for layout in self.layouts.values():
+            layout.remove_legend_ax()
 
     def freeze(self, figure=None, scale=1, _debug=False):
-        figsize = np.asarray(self.get_figure_size()) * scale
+        # If not composed, update the figsize.
+        # When composed, the parent is expected to have pushed its figsize
+        # down with set_figsize before calling freeze.
+        if not self.is_composite:
+            self.figsize = np.asarray(self.get_figure_size())
+        figsize = self.figsize * scale
 
         if figure is None:
             figure = plt.figure(figsize=figsize)
-        else:
+        elif not self.is_composite:
             figure.set_size_inches(figsize)
 
         # To freeze all the layouts

--- a/src/marsilea/layout.py
+++ b/src/marsilea/layout.py
@@ -610,11 +610,10 @@ class CrossLayout(_MarginMixin):
         -------
 
         """
-        # If not composed, update the figsize
+        # If not composed, update the figsize.
+        # When composed, the parent is expected to have pushed its figsize
+        # down with set_figsize before calling freeze.
         if not self.is_composite:
-            self.figsize = np.array(self.get_figure_size())
-        # Fallback: if figsize was not set by parent, compute it
-        if self.figsize is None:
             self.figsize = np.array(self.get_figure_size())
         figsize = self.figsize * scale
         if figure is None:
@@ -1050,19 +1049,28 @@ class StackCrossLayout(_MarginMixin):
     def _get_layout_heights(self):
         return [layout.get_bbox_height() for layout in self.layouts]
 
-    def _get_spacing_widths(self):
+    def _spacing_total(self):
         return self.spacing * (len(self.layouts) - 1)
 
-    def _get_spacing_heights(self):
-        return self.spacing * (len(self.layouts) - 1)
+    def _get_center_halves(self, low, high, mains):
+        """Extent on either side of the centerline for `align="center"`.
+
+        Every layout is anchored by its main canvas, so the room needed is
+        measured from the centered main edges, not from the widest bbox.
+        """
+        mains = np.asarray(mains) / 2
+        lows = np.asarray([layout.get_side_size(low) for layout in self.layouts])
+        highs = np.asarray([layout.get_side_size(high) for layout in self.layouts])
+        return np.max(lows + mains), np.max(highs + mains)
 
     def get_bbox_width(self):
         ws = self._get_layout_widths()
         if self.direction == "horizontal":
-            return np.sum(ws) + self._get_spacing_widths()
+            return np.sum(ws) + self._spacing_total()
         else:
             if self.align == "center":
-                return np.max(ws)
+                mains = [layout.get_main_width() for layout in self.layouts]
+                return np.sum(self._get_center_halves("left", "right", mains))
             elif self.align == "left":
                 left_sides = np.asarray(
                     [layout.get_side_size("left") for layout in self.layouts]
@@ -1079,10 +1087,11 @@ class StackCrossLayout(_MarginMixin):
     def get_bbox_height(self):
         hs = self._get_layout_heights()
         if self.direction == "vertical":
-            return np.sum(hs) + self._get_spacing_heights()
+            return np.sum(hs) + self._spacing_total()
         else:
             if self.align == "center":
-                return np.max(hs)
+                mains = [layout.get_main_height() for layout in self.layouts]
+                return np.sum(self._get_center_halves("bottom", "top", mains))
             elif self.align == "top":
                 top_sides = np.asarray(
                     [layout.get_side_size("top") for layout in self.layouts]
@@ -1099,9 +1108,27 @@ class StackCrossLayout(_MarginMixin):
     def get_bbox_size(self):
         return self.get_bbox_width(), self.get_bbox_height()
 
+    def _get_legend_extent(self, sides):
+        """The room the legend axes needs on one of the two figure axes"""
+        if self._legend_axes is None:
+            return 0
+        if self._legend_axes.side not in sides:
+            return 0
+        return self._legend_axes.get_length()
+
     def get_figure_size(self):
-        fig_w = self.get_bbox_width() + self.get_margin_w()
-        fig_h = self.get_bbox_height() + self.get_margin_h()
+        # The legend is placed outside the bbox, so the figure has to grow
+        # for it; get_bbox_size stays the size of the stacked content.
+        fig_w = (
+            self.get_bbox_width()
+            + self.get_margin_w()
+            + self._get_legend_extent({"left", "right"})
+        )
+        fig_h = (
+            self.get_bbox_height()
+            + self.get_margin_h()
+            + self._get_legend_extent({"top", "bottom"})
+        )
         return fig_w, fig_h
 
     def set_figsize(self, figsize):
@@ -1149,9 +1176,17 @@ class StackCrossLayout(_MarginMixin):
             else:
                 return self.layouts[0].get_side_size("top")
 
+    def _get_content_origin(self):
+        """Bottom-left of the stacked content, leaving room for the legend"""
+        return (
+            self.margin.left + self._get_legend_extent({"left"}),
+            self.margin.bottom + self._get_legend_extent({"bottom"}),
+        )
+
     def get_layout_anchors(self):
         """Get the anchor points of all layouts assume the layout is not composite"""
-        base_x, base_y = self.margin.left, self.margin.bottom
+        origin_x, origin_y = self._get_content_origin()
+        base_x, base_y = origin_x, origin_y
         xs, ys = [], []
         if self.direction == "horizontal":
             # x is always the same regardless of the alignment
@@ -1165,20 +1200,18 @@ class StackCrossLayout(_MarginMixin):
                 )
             # only y is different
             if self.align == "bottom":
-                base_y = self.margin.bottom + self._get_layouts_offset("bottom")
+                base_y = origin_y + self._get_layouts_offset("bottom")
                 ys = [base_y for _ in range(len(self.layouts))]
             elif self.align == "top":
                 base_y = (
-                    self.margin.bottom
-                    + self.get_bbox_height()
-                    - self._get_layouts_offset("top")
+                    origin_y + self.get_bbox_height() - self._get_layouts_offset("top")
                 )
                 ys = [base_y - layout.get_main_height() for layout in self.layouts]
             else:
-                center_y = self.margin.bottom + self.get_bbox_height() / 2
-                ys = [
-                    center_y - layout.get_main_height() / 2 for layout in self.layouts
-                ]
+                mains = [layout.get_main_height() for layout in self.layouts]
+                half_bottom, _ = self._get_center_halves("bottom", "top", mains)
+                center_y = origin_y + half_bottom
+                ys = [center_y - main / 2 for main in mains]
         else:
             # y is always the same regardless of the alignment
             for layout in self.layouts[::-1]:
@@ -1191,18 +1224,18 @@ class StackCrossLayout(_MarginMixin):
                 )
             # only x is different
             if self.align == "left":
-                base_x = self.margin.left + self._get_layouts_offset("left")
+                base_x = origin_x + self._get_layouts_offset("left")
                 xs = [base_x for _ in range(len(self.layouts))]
             elif self.align == "right":
                 base_x = (
-                    self.margin.left
-                    + self.get_bbox_width()
-                    - self._get_layouts_offset("right")
+                    origin_x + self.get_bbox_width() - self._get_layouts_offset("right")
                 )
                 xs = [base_x - layout.get_main_width() for layout in self.layouts]
             else:
-                center_x = self.margin.left + self.get_bbox_width() / 2
-                xs = [center_x - layout.get_main_width() / 2 for layout in self.layouts]
+                mains = [layout.get_main_width() for layout in self.layouts]
+                half_left, _ = self._get_center_halves("left", "right", mains)
+                center_x = origin_x + half_left
+                xs = [center_x - main / 2 for main in mains]
             ys = ys[::-1]
 
         return np.array(list(zip(xs, ys)))
@@ -1230,11 +1263,10 @@ class StackCrossLayout(_MarginMixin):
         self._legend_axes.size = size
 
     def freeze(self, figure=None, scale=1, _debug=False):
-        # If not composed, update the figsize
+        # If not composed, update the figsize.
+        # When composed, the parent is expected to have pushed its figsize
+        # down with set_figsize before calling freeze.
         if not self.is_composite:
-            self.figsize = np.array(self.get_figure_size())
-        # Fallback: if figsize was not set by parent, compute it
-        if self.figsize is None:
             self.figsize = np.array(self.get_figure_size())
         figsize = self.figsize * scale
         if figure is None:
@@ -1259,7 +1291,21 @@ class StackCrossLayout(_MarginMixin):
 
         if self._legend_axes is not None:
             bbox_w, bbox_h = self.get_bbox_size()
-            ax, ay = main_anchor
+            # The bottom-left of the stacked content, from the final
+            # anchors: those point at each main canvas, so back out the
+            # side plots to reach the corner of the bbox.
+            ax = np.min(
+                [
+                    x - lo.get_side_size("left")
+                    for (x, _), lo in zip(anchors, self.layouts)
+                ]
+            )
+            ay = np.min(
+                [
+                    y - lo.get_side_size("bottom")
+                    for (_, y), lo in zip(anchors, self.layouts)
+                ]
+            )
 
             side = self._legend_axes.side
             size = self._legend_axes.size

--- a/src/marsilea/upset.py
+++ b/src/marsilea/upset.py
@@ -1086,8 +1086,8 @@ class Upset(WhiteBoard):
         # highlight_legend.set_figure(None)
         return {"highlight_subsets": [highlight_legend]}
 
-    def render(self, figure=None, scale=1):
-        super().render(figure=figure, scale=scale)
+    def _draw(self, figure):
+        super()._draw(figure)
         main_ax = self.get_main_ax()
         self._render_matrix(main_ax)
         # apply highlight style to bar

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -1,11 +1,27 @@
 """Tests for CompositeBoard, StackBoard, ZeroWidth, ZeroHeight."""
 
+import pytest
+
 import marsilea as ma
 import marsilea.plotter as mp
 
 
 def _make_heatmap(rng, rows=5, cols=4):
     return ma.Heatmap(rng.standard_normal((rows, cols)))
+
+
+def _bounds(figure):
+    return [ax.get_position().bounds for ax in figure.axes]
+
+
+def _assert_inside_figure(figure):
+    """Every axes must sit within the figure, nothing clipped off the edge"""
+    for ax in figure.axes:
+        x0, y0, w, h = ax.get_position().bounds
+        assert x0 >= -1e-9 and y0 >= -1e-9, f"{ax} starts outside the figure"
+        assert x0 + w <= 1 + 1e-9 and y0 + h <= 1 + 1e-9, (
+            f"{ax} ends outside the figure"
+        )
 
 
 # --- CompositeBoard ---
@@ -68,15 +84,115 @@ def test_stack_vertical(rng):
 
 
 def test_stack_nested(rng):
-    """Nesting StackBoards (grid of heatmaps)."""
-    h1 = _make_heatmap(rng)
-    h2 = _make_heatmap(rng)
-    h3 = _make_heatmap(rng)
-    h4 = _make_heatmap(rng)
+    """Nesting StackBoards must give a real grid, not four overlapping axes."""
+    data = rng.standard_normal((5, 4))
+    cmaps = ["Reds", "Greens", "Blues", "Purples"]
+    h1, h2, h3, h4 = [ma.Heatmap(data, cmap=c, width=1, height=1) for c in cmaps]
     sb1 = ma.StackBoard([h1, h2], direction="horizontal")
     sb2 = ma.StackBoard([h3, h4], direction="horizontal")
     grid = ma.StackBoard([sb1, sb2], direction="vertical")
     grid.render()
+
+    bounds = _bounds(grid.figure)
+    assert len(bounds) == 4
+    # two columns and two rows, no axes sharing a corner with another
+    assert len({round(b[0], 6) for b in bounds}) == 2
+    assert len({round(b[1], 6) for b in bounds}) == 2
+    assert len({(round(b[0], 6), round(b[1], 6)) for b in bounds}) == 4
+    _assert_inside_figure(grid.figure)
+
+    # every heatmap draws its own mesh, with its own colormap
+    drawn = []
+    for ax in grid.figure.axes:
+        meshes = [c for c in ax.collections if hasattr(c, "cmap")]
+        assert len(meshes) == 1
+        drawn.append(meshes[0].cmap.name)
+    assert sorted(drawn) == sorted(cmaps)
+
+
+def test_stack_nested_thrice(rng):
+    """A stack of stacks of stacks still places every board once."""
+    inner = [
+        ma.StackBoard([_make_heatmap(rng), _make_heatmap(rng)], direction="horizontal")
+        for _ in range(2)
+    ]
+    grid = ma.StackBoard(inner, direction="vertical")
+    outer = ma.StackBoard([grid, _make_heatmap(rng)], direction="horizontal")
+    outer.render()
+
+    assert len(outer.figure.axes) == 5
+    assert len({(round(b[0], 6), round(b[1], 6)) for b in _bounds(outer.figure)}) == 5
+    _assert_inside_figure(outer.figure)
+
+
+def test_stack_leaves_input_boards_alone(rng):
+    """Boards are copied on construction, so the originals stay renderable."""
+    h1 = _make_heatmap(rng)
+    h2 = _make_heatmap(rng)
+    ma.StackBoard([h1, h2], direction="horizontal").render()
+
+    assert h1.figure is None
+    h1.render()  # the original is untouched and still usable on its own
+
+
+def test_stack_after_render(rng):
+    """Stacking already-rendered boards must not copy live figure/axes.
+
+    The StackBoard side of ``test_composite_after_render``: the Violin
+    gives the axes a categorical unit whose matplotlib ``UnitData`` holds
+    an ``itertools.count``, which cannot be copied on Python 3.14+.
+    """
+    h1 = _make_heatmap(rng)
+    h1.add_top(mp.Violin(rng.standard_normal((6, 4))))
+    h2 = _make_heatmap(rng)
+    h1.render()
+    h2.render()
+
+    sb = ma.StackBoard([h1, h2], direction="horizontal")
+    nested = ma.StackBoard([sb, _make_heatmap(rng)], direction="vertical")
+    nested.render()
+
+    assert nested.figure is not h1.figure
+    assert h1.figure is not None
+
+
+def test_stack_save_before_render(rng, tmp_path):
+    sb = ma.StackBoard([_make_heatmap(rng)], direction="horizontal")
+    out = tmp_path / "stack.png"
+    sb.save(out)
+    assert out.stat().st_size > 0
+
+
+def test_stack_empty_boards():
+    with pytest.raises(ValueError, match="empty list"):
+        ma.StackBoard([])
+
+
+@pytest.mark.parametrize("side", ["right", "left", "top", "bottom"])
+def test_stack_legend_inside_figure(rng, side):
+    """The figure has to grow for the legend instead of pushing it off-canvas."""
+    sb = ma.StackBoard([_make_heatmap(rng), _make_heatmap(rng)], direction="horizontal")
+    sb.add_legends(side=side)
+    sb.render()
+
+    legend_ax = sb.layout.get_legend_ax()
+    assert legend_ax is not None
+    _assert_inside_figure(sb.figure)
+
+
+@pytest.mark.parametrize(
+    "direction,align,add_side,n",
+    [("vertical", "center", "left", 5), ("horizontal", "center", "top", 4)],
+)
+def test_stack_center_align_asymmetric(rng, direction, align, add_side, n):
+    """Centering on the main canvas must still leave room for side plots."""
+    h1 = ma.Heatmap(rng.standard_normal((5, 4)), width=1, height=1)
+    getattr(h1, f"add_{add_side}")(mp.Colors(rng.standard_normal(n)), size=1.5, pad=0.1)
+    h2 = ma.Heatmap(rng.standard_normal((5, 4)), width=1, height=1)
+
+    sb = ma.StackBoard([h1, h2], direction=direction, align=align)
+    sb.render()
+    _assert_inside_figure(sb.figure)
 
 
 # --- ZeroWidth ---

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -199,6 +199,63 @@ def test_stack_keeps_per_board_legends(rng):
     _assert_no_overlap(sb.figure)
 
 
+def test_stack_of_composites(rng):
+    """A CompositeBoard can be stacked, which is another way to a grid."""
+    data = rng.standard_normal((5, 4))
+    cmaps = ["Reds", "Greens", "Blues", "Purples"]
+    h1, h2, h3, h4 = [ma.Heatmap(data, cmap=c, width=1, height=1) for c in cmaps]
+    grid = ma.StackBoard([h1 + h2, h3 + h4], direction="vertical")
+    grid.render()
+
+    bounds = _bounds(grid.figure)
+    assert len(bounds) == 4
+    assert len({round(b[0], 6) for b in bounds}) == 2
+    assert len({round(b[1], 6) for b in bounds}) == 2
+    _assert_inside_figure(grid.figure)
+    _assert_no_overlap(grid.figure)
+
+    drawn = [c.cmap.name for ax in grid.figure.axes for c in ax.collections]
+    assert sorted(drawn) == sorted(cmaps)
+
+
+@pytest.mark.parametrize("direction", ["horizontal", "vertical"])
+def test_stack_mixed_children(rng, direction):
+    """A stack can hold a composite, another stack and a plain board at once."""
+    sb = ma.StackBoard(
+        [
+            _make_heatmap(rng) + _make_heatmap(rng),
+            ma.StackBoard([_make_heatmap(rng), _make_heatmap(rng)]),
+            _make_heatmap(rng),
+        ],
+        direction=direction,
+    )
+    sb.render()
+
+    assert len(sb.figure.axes) == 5
+    _assert_inside_figure(sb.figure)
+    _assert_no_overlap(sb.figure)
+
+
+def test_stack_composite_keeps_own_legend(rng):
+    """A composite legend is added after concatenation, and must survive."""
+    comp = _make_heatmap(rng) + _make_heatmap(rng)
+    comp.add_legends(side="right")
+    sb = ma.StackBoard(
+        [comp, _make_heatmap(rng)], direction="vertical", keep_legends=True
+    )
+    sb.render()
+
+    assert sum(len(ax.artists) > 0 for ax in sb.figure.axes) == 1
+    _assert_inside_figure(sb.figure)
+
+
+def test_stack_inside_composite_is_refused(rng):
+    """The other direction is not supported, and says so."""
+    sb = ma.StackBoard([_make_heatmap(rng), _make_heatmap(rng)])
+    with pytest.raises(TypeError, match="Cannot append object type"):
+        _make_heatmap(rng) + sb
+
+
 @pytest.mark.parametrize("side", ["right", "left", "top", "bottom"])
 def test_stack_legend_inside_figure(rng, side):
     """The figure has to grow for the legend instead of pushing it off-canvas."""

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -24,6 +24,20 @@ def _assert_inside_figure(figure):
         )
 
 
+def _assert_no_overlap(figure):
+    """No two axes may cover the same area"""
+    boxes = _bounds(figure)
+    for i, (xi, yi, wi, hi) in enumerate(boxes):
+        for j, (xj, yj, wj, hj) in enumerate(boxes[i + 1 :], start=i + 1):
+            apart = (
+                xi + wi <= xj + 1e-6
+                or xj + wj <= xi + 1e-6
+                or yi + hi <= yj + 1e-6
+                or yj + hj <= yi + 1e-6
+            )
+            assert apart, f"axes {i} and {j} overlap"
+
+
 # --- CompositeBoard ---
 
 
@@ -166,6 +180,23 @@ def test_stack_save_before_render(rng, tmp_path):
 def test_stack_empty_boards():
     with pytest.raises(ValueError, match="empty list"):
         ma.StackBoard([])
+
+
+def test_stack_keeps_per_board_legends(rng):
+    """keep_legends=True: each board draws its own legend, with room for it."""
+    h1 = _make_heatmap(rng)
+    h1.add_legends()
+    h2 = _make_heatmap(rng)
+    h2.add_legends()
+
+    sb = ma.StackBoard([h1, h2], direction="horizontal", keep_legends=True)
+    sb.render()
+
+    # two heatmaps plus a legend axes each, none clipped or overlapping
+    assert len(sb.figure.axes) == 4
+    assert sum(len(ax.artists) > 0 for ax in sb.figure.axes) == 2
+    _assert_inside_figure(sb.figure)
+    _assert_no_overlap(sb.figure)
 
 
 @pytest.mark.parametrize("side", ["right", "left", "top", "bottom"])


### PR DESCRIPTION
## The bug

A `StackBoard` of `StackBoard`s drew every heatmap on top of the others at full figure size. The tutorial's "Grid of heatmaps" example rendered as a single purple heatmap with visible ticks instead of a 2×2 grid:

```
figsize [2.2 2.2]  n_axes 8              <- should be 4
0 [0.000, 0.545, 0.455, 0.455] []        <- correctly placed, EMPTY -> the visible ticks
1 [0.545, 0.545, 0.455, 0.455] []
2 [0.000, 0.000, 1.000, 1.000] ['Reds']  <- all four full-figure, stacked
3 [0.000, 0.000, 1.000, 1.000] ['Greens']
4 [0.000, 0.000, 0.455, 0.455] []
5 [0.545, 0.000, 0.455, 0.455] []
6 [0.000, 0.000, 1.000, 1.000] ['Blues']
7 [0.000, 0.000, 1.000, 1.000] ['Purples'] <- last one wins visually
```

Nothing was shared between the colormaps — it was pure axes overlap.

## Root cause

`_copy_board` deep-copies `board.layout` but shallow-copied the nested board list:

```python
new.layout = deepcopy(board.layout)              # fresh child layouts
...
if hasattr(board, "_board_list"):
    new._board_list = list(board._board_list)    # same child boards
```

A copied group board therefore kept the original children, whose `.layout` was the pre-copy object that never entered the frozen tree. The parent positioned the copies (the four empty axes); each child then froze its orphan layout with `figsize=None` and `anchor=(0, 0)`, landing at `(0, 0, 1, 1)`.

Flat `StackBoard` worked because there the child's `.layout` *is* the object handed to `StackCrossLayout`.

## The fix

`_copy_board` now takes the sub-layout a child should be bound to, and a group board copies its children against the layouts that already live in its own freshly copied tree:

```python
new._board_list = [
    _copy_board(child, layout=sub)
    for child, sub in zip(board._board_list, sub_layouts, strict=True)
]
```

Plotters stay shared by reference. That is deliberate and required by #102: deep-copying them drags in the live matplotlib artists a rendered plotter keeps — a `Bar` plotter holds its `BarContainer`, and any categorical axis holds a `category.UnitData` wrapping an `itertools.count`, which is not copyable on Python 3.14+. The `hasattr` ladder is collapsed into one loop over a named tuple of attributes, so the shared-vs-copied contract is stated in one place.

## Also in this PR

- **`_GroupBoard`**, shared by `CompositeBoard` and `StackBoard`, replaces ~90 duplicated lines and fixes the drift between them: `CompositeBoard.render` and `save` now return `self`, as does `StackBoard.set_margin`, and `StackBoard.save()` before `render()` no longer raises `AttributeError` for a missing `figure` attribute.
- **Freeze/draw split.** Drawing moves out of `render` into `_draw`, so a group board freezes the whole layout tree once instead of every child re-freezing its own and `initiate_axes` removing and re-adding each axes. On a six-board stack (heatmap + dendrogram + title each) axes creation drops from **48 calls to 24** and render from **0.131 s to 0.078 s**, with identical output. `ClusterBoard.render` collapses into `_freeze_flex_plots` + `_draw`.
- **Both `figsize was not set by parent` fallbacks are gone.** They were added in the same commit that introduced this bug (#82) and only masked it. Instrumented over the suite, no layout now reaches `freeze` with `figsize` unset; without them a future linkage break raises instead of silently drawing in the wrong place.
- **Three `StackCrossLayout` defects**, all reproduced first:
  - legend axes were placed outside the figure on every side (`side="right"` put them at `[1.0, 0.0, 0.51, 1.0]`; only `save()`'s `bbox_inches="tight"` hid it);
  - `align="center"` overflowed to `x0=-0.308` for a board with a wide one-sided companion plot, because the bbox was sized by `max(bbox)` while each board is anchored by its main canvas;
  - the legend rect used a `main_anchor` computed before the anchors were offset.
- `StackBoard([])` now raises a clear `ValueError` instead of failing later inside numpy.

## Tests

The three existing `StackBoard` tests only asserted that `render()` did not raise — exactly what the bug did, which is how #82 shipped this. They now assert geometry, colormaps, legend placement and figure containment.

Seventeen new tests, all failing against the previous code (`test_stack_nested` fails with `assert 8 == 4`). `test_stack_after_render` is the StackBoard side of #102's `test_composite_after_render`: it stacks and nest-stacks boards that were already rendered and carry a categorical axis.

Verified with CI's own command (`uv sync --dev && pytest tests/`) on **Python 3.14 and 3.12: 616 passed, 6 xfailed** each. `ruff check` and `ruff format` clean.

## Docs

`stack.rst`'s `.. warning:: still considered experimental ... issues with the rendering` was describing these bugs, so it is replaced with the one real remaining limitation: `get_ax` / `get_main_ax` only reach boards stacked directly, not those inside a nested stack (nested layouts are keyed by an internal `uuid4().hex`). That behaviour is unchanged here.

Worth knowing: `stack.rst` has exactly eight `.. plot::` directives, so `stack-8.png` — the broken grid — is the tutorial card thumbnail in `docs/source/tutorial/index.rst`. The docs were rebuilt with no sphinx errors and it is now the correct 2×2 grid.

## Follow-ups in this PR

**Per-board legends (Copilot review).** With `keep_legends=True` the group board froze only its own legend before freezing the tree, so a child never got a legend axes and `_draw` crashed in `_render_legend`. `_freeze_legend` now recurses into the boards. Since a legend is an ordinary side cell, doing it in that order also makes the stack leave room for it — before, one child legend overlapped the next board and the last was placed entirely outside the figure.

**`CompositeBoard` can now be stacked.** `ma.StackBoard([h1 + h2, h3 + h4])` used to raise `AttributeError: 'CompositeCrossLayout' object has no attribute 'remove_legend_ax'`. `StackCrossLayout` drives its children through the `CrossLayout` API and `CompositeCrossLayout` implemented only part of it, so the rest is filled in: `remove_legend_ax`, `set_figsize`, `get_main_width`/`get_main_height`, a `name` for the layout mapper, an anchor that `freeze` actually honours (`set_anchor` used to forward to the main layout and then be ignored), and an `is_composite` guard on `set_size_inches` so a nested composite no longer resizes the figure its parent owns.

Verified across directions, all six align modes, composites carrying side plots, a stack holding a composite *and* a nested stack *and* a plain board, group-level legends, composites keeping their own legend, and numeric pad appends — no axes clipped or overlapping in any of them. The reverse direction is unchanged and still raises `Cannot append object type of StackCrossLayout`, now pinned by a test.

## Out of scope, spotted while confirming the above

- `add_layer` never sets `plot._registered`, unlike `add_plot`, so one plotter object can be silently shared by two boards. (Partly addressed by #103; worth a look.)
- Appending a `StackBoard` to a `CompositeBoard` (`h + stackboard`) is still unsupported. It needs `main_cell` and `set_main_width`/`set_main_height` on `StackCrossLayout`, plus a decision on what "align to the main canvas" means for a stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
