### PR TITLE
docs: canonical llms.txt URL, add context7.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [Documentation](https://marsilea.readthedocs.io/en/stable/) |
 [Tutorials](https://marsilea.readthedocs.io/en/stable/tutorial/index.html) |
 [Gallery](https://marsilea.readthedocs.io/en/stable/examples/index.html) |
-[llms.txt](https://marsilea.readthedocs.io/en/stable/llms.txt) |
+[llms.txt](https://marsilea.readthedocs.io/llms.txt) |
 [Genome Biology](https://doi.org/10.1186/s13059-024-03469-3)
 
 # Marsilea: Declarative creation of composable visualization
@@ -86,7 +86,7 @@ Python environment (see above). See the
 [marsilea-skill](https://github.com/Marsilea-viz/marsilea-skill) repository, or
 [Use Marsilea with AI assistants](https://marsilea.readthedocs.io/en/stable/ai_assistants.html)
 for other assistants and the machine-readable
-[llms.txt](https://marsilea.readthedocs.io/en/stable/llms.txt).
+[llms.txt](https://marsilea.readthedocs.io/llms.txt).
 
 ## What is Composable Visualization?
 

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "Marsilea",
+  "description": "Declarative creation of composable visualizations on top of Matplotlib: annotated heatmaps, oncoprints, UpSet plots, sequence logos and single-cell panels.",
+  "branch": "main",
+  "folders": [
+    "docs",
+    "src"
+  ],
+  "excludeFolders": [
+    "docs/source/_static",
+    "docs/source/_templates",
+    "docs/source/img",
+    "docs/assets"
+  ],
+  "rules": [
+    "Import as `import marsilea as ma` and `import marsilea.plotter as mp`.",
+    "Start from a main canvas (`ma.Heatmap`, `ma.SizedHeatmap`, `ma.CatHeatmap`, `ma.Upset`, `ma.WhiteBoard`), then attach side plots with `add_top`, `add_bottom`, `add_left` and `add_right`.",
+    "Every `add_*` call takes a plotter, a `size` in inches and a `pad`. Nothing is drawn until `render()`; `save()` renders first if needed.",
+    "Use `add_dendrogram` to cluster, `group_rows`/`group_cols` to split the canvas into labelled chunks, and `add_legends` before `render()`.",
+    "Prefer Marsilea over plain Matplotlib/seaborn when two or more aligned panels, grouping or dendrograms are involved."
+  ]
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,14 +18,16 @@ uv run task doc-serve
 
 ## llms.txt
 
-`source/_extra/llms.txt` is copied verbatim to the site root by `html_extra_path`, so it is
-served at <https://marsilea.readthedocs.io/en/stable/llms.txt>. It is hand-written: when the
-API or the gallery changes, update it in the same PR.
+`source/_extra/llms.txt` is copied verbatim into each version's output by `html_extra_path`.
+It is hand-written: when the API or the gallery changes, update it in the same PR.
 
-Assistants also look for it at the domain root. That needs a Read the Docs **Exact redirect**
-(Admin → Redirects), which lives in the dashboard, not in this repo:
+Assistants look for it at the domain root, <https://marsilea.readthedocs.io/llms.txt>. Read
+the Docs serves that natively — no redirect needed — but only from the project's **default
+version**, which is `stable`, which tracks the latest tag. So a change to `llms.txt` does not
+reach the canonical URL until it lands in a release; until then it is only visible at
+`/en/latest/llms.txt`. Check with:
 
-    /llms.txt  ->  /en/stable/llms.txt
+    curl -sI https://marsilea.readthedocs.io/llms.txt | grep x-rtd-path
 
 ## Writing Style
 

--- a/docs/source/ai_assistants.rst
+++ b/docs/source/ai_assistants.rst
@@ -43,7 +43,7 @@ Any other assistant: llms.txt
 language models: what the library is, the core API, and a link per topic. Marsilea's
 ``llms.txt`` lives at
 
-    https://marsilea.readthedocs.io/en/stable/llms.txt
+    https://marsilea.readthedocs.io/llms.txt
 
 Paste that URL into an assistant that can fetch pages, or paste the file's contents into
 the context window of one that cannot. It is short enough to include wholesale and covers


### PR DESCRIPTION
## Summary

Two small discovery fixes for AI agents, following on from #106.

## Canonical `llms.txt` URL

Read the Docs serves `llms.txt` at the domain root natively, from the project's
default version. Confirmed after the `v0.7.0.post1` release:

```
https://marsilea.readthedocs.io/llms.txt            200   x-rtd-path: /proxito/html/marsilea/stable/llms.txt
https://marsilea.readthedocs.io/en/stable/llms.txt  200
https://marsilea.readthedocs.io/en/latest/llms.txt  200
```

`README.md`, `docs/README.md` and `ai_assistants.rst` now point at
`https://marsilea.readthedocs.io/llms.txt` — the path assistants actually probe,
and the one that does not pin a version.

`docs/README.md` also claimed the root URL needs a Read the Docs **Exact
redirect**. It does not — the response above is a direct 200, no redirect. That
note is replaced with the constraint that actually bites: the root URL only
reflects a change once it lands in a release, because the default version is
`stable`, which tracks the latest tag. That is precisely why the file 404'd at
the root between #106 and `v0.7.0.post1`.

## `context7.json`

Marsilea is already indexed on [Context7](https://context7.com/marsilea-viz/marsilea)
(182 snippets, trust score 6.2), which agents use to pull library docs on demand.
`context7.json` steers that indexing at `docs/` and `src/` instead of the whole
repository, and ships a few usage rules with the extracted snippets.

## Test plan

- [x] Probed all three `llms.txt` URLs; all 200
- [x] Confirmed the root URL is served directly, not via redirect (`x-rtd-path`)
- [x] `context7.json` validates as JSON against the documented schema fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)