### PR TITLE
fix: report data errors where the mistake was made

### DIFF
--- a/src/marsilea/_deform.py
+++ b/src/marsilea/_deform.py
@@ -169,12 +169,35 @@ class Deformation:
         if breakpoints is None:
             return
         state = self._axes[axis]
+        cuts = np.sort(np.asarray(breakpoints))
+        self._check_cuts(axis, cuts, state.n)
         state.is_split = True
-        state.breakpoints = [0, *np.sort(np.asarray(breakpoints)), state.n]
+        state.breakpoints = [0, *cuts, state.n]
         if order is None:
             order = np.arange(len(breakpoints) + 1)
         state.split_order = order
         state.plan = None
+
+    @staticmethod
+    def _check_cuts(axis, cuts, n):
+        """Reject cut positions that cannot split the axis.
+
+        Out of range used to pass silently: the chunk it describes is empty, so
+        the plot simply came out wrong with nothing said about it.
+        """
+        unit = "row" if axis == _ROW else "column"
+        outside = [int(c) for c in cuts if c < 1 or c > n - 1]
+        if outside:
+            raise ValueError(
+                f"Cannot cut {unit}s at {outside}, there are only {n} {unit}s. "
+                f"Cuts go between 1 and {n - 1}."
+            )
+        repeated = sorted({int(c) for c in cuts if list(cuts).count(c) > 1})
+        if repeated:
+            raise ValueError(
+                f"Cannot cut {unit}s at {repeated} twice, "
+                f"that would leave an empty group."
+            )
 
     def set_split_row(self, breakpoints=None, order=None):
         self._set_split(_ROW, breakpoints, order)

--- a/src/marsilea/_normalize.py
+++ b/src/marsilea/_normalize.py
@@ -110,3 +110,89 @@ def check_length(name, arr, shape, axis):
             f"built?"
         )
         raise ValueError(msg)
+
+
+def _plural(n, unit):
+    return f"{n} {unit}" if n == 1 else f"{n} {unit}s"
+
+
+def check_plot_data(plot, side, axis, shape):
+    """Reject plotter data that cannot align with the board it is added to.
+
+    Boards render lazily, so a length mismatch used to surface inside
+    :class:`~marsilea._deform.Deformation` with the caller's ``add_*`` line
+    nowhere in the traceback. This asks the same question at the ``add_*``
+    call instead.
+
+    It asks exactly what `Deformation` asks at render: the same axis, the same
+    ``shape[-1]`` rule, and the same set of plans that get a deformation at
+    all. So it can only reject what the render would reject anyway.
+
+    Parameters
+    ----------
+    plot : RenderPlan
+        The plotter being added, already built (never a deferred one).
+    side : str
+        Where it is going, ``"main"`` for a layer.
+    axis : {"row", "col", "main"}
+        Which board axis its data indexes, from :meth:`RenderPlan.data_axis`.
+    shape : tuple or None
+        ``(nrow, ncol)`` of the board, or None when it has no fixed grid.
+
+    """
+    if shape is None:
+        return
+    if side != "main" and not plot.allow_split:
+        # Never handed a deformation, so its data is drawn as given.
+        return
+    datasets = plot.get_data()
+    if datasets is None:
+        return
+
+    name = type(plot).__name__
+    for data in datasets:
+        if data is None:
+            continue
+        try:
+            arr = np.asarray(data)
+        except Exception:  # ragged or exotic input; the render will speak up
+            continue
+        if arr.ndim == 0:
+            continue
+        if axis == "main":
+            if arr.ndim == 2 and arr.shape != shape:
+                msg = f"`{name}` has shape {arr.shape}, but the board is {shape}."
+                if arr.shape == shape[::-1]:
+                    msg += " That looks transposed, try `data.T`."
+                raise ValueError(msg)
+            continue
+
+        expect, other = (shape[0], shape[1]) if axis == "row" else (shape[1], shape[0])
+        got = arr.shape[-1]
+        if got == expect:
+            continue
+        unit = "row" if axis == "row" else "column"
+        msg = (
+            f"`{name}` on {side!r} has {_plural(got, 'value')}, "
+            f"but there are {_plural(expect, unit)}."
+        )
+        orient = getattr(plot, "orient", None)
+        if orient is not None:
+            # A pinned orient fixes the axis whatever side the plot is on, so
+            # "try the other side" would be wrong advice here.
+            msg += f" orient={orient!r} reads values along {unit}s on any side."
+        elif got == other:
+            # A length that fits the other axis is almost always a plot that
+            # went on the wrong side.
+            other_unit = "column" if axis == "row" else "row"
+            sides = (
+                "`add_top` or `add_bottom`"
+                if axis == "row"
+                else ("`add_left` or `add_right`")
+            )
+            msg += f" There are {_plural(other, other_unit)}, so try {sides} instead."
+        else:
+            msg += (
+                " Left and right take one value per row, top and bottom one per column."
+            )
+        raise ValueError(msg)

--- a/src/marsilea/base.py
+++ b/src/marsilea/base.py
@@ -13,7 +13,7 @@ from matplotlib.artist import Artist
 from matplotlib.colors import is_color_like
 from matplotlib.figure import Figure
 
-from ._normalize import densify
+from ._normalize import check_plot_data, densify
 from ._sources import accepts_source, resolve, resolve_group
 from ._deform import Deformation
 from .dendrogram import Dendrogram
@@ -23,7 +23,7 @@ from .plotter import RenderPlan, Title, SizedMesh
 from .plotter._seaborn import _SeabornBase
 from .plotter.base import _DeferredPlot
 from .plotter.mesh import MeshBase
-from .utils import pairwise, batched, get_plot_name, _check_side
+from .utils import pairwise, batched, caller_location, get_plot_name, _check_side
 
 
 # Attributes whose container must not be shared with the source board,
@@ -83,6 +83,23 @@ def _copy_board(board, layout=None):
             new.main_board = new._board_list[0]
 
     return new
+
+
+def _render_with_context(plan, axes):
+    """Render one plan, tagging any failure with where the plan came from.
+
+    A board is built lazily, so the only user frame in a render traceback is
+    ``render()`` itself. Notes keep the original exception intact, its type,
+    its message and its traceback, and add the two things it cannot know:
+    which plotter blew up, and the ``add_*`` line that put it there.
+    """
+    try:
+        plan.render(axes)
+    except Exception as e:
+        e.add_note(f"  while rendering {type(plan).__name__} on '{plan.side}'")
+        if plan._added_at is not None:
+            e.add_note(f"  added at {plan._added_at}")
+        raise
 
 
 def reorder_index(arr, order=None):
@@ -417,6 +434,10 @@ class WhiteBoard(LegendMaker):
         )
         if plot._registered:
             raise DuplicatePlotter(plot)
+        # Before the layout is touched: a rejected plot must not leave an
+        # orphan axes behind for the next render to trip over.
+        check_plot_data(plot, side, plot.data_axis(side), self._board_shape())
+        plot._added_at = caller_location()
         plot_name = get_plot_name(name, side, plot.__class__.__name__)
         self._legend_switch[plot_name] = legend
 
@@ -518,16 +539,13 @@ class WhiteBoard(LegendMaker):
         return self.add_plot("bottom", plot, name, size, pad, legend)
 
     def _render_plan(self):
-        try:
-            for plan in self._col_plan + self._row_plan:
-                axes = self.layout.get_ax(plan.name)
-                plan.render(axes)
+        for plan in self._col_plan + self._row_plan:
+            axes = self.layout.get_ax(plan.name)
+            _render_with_context(plan, axes)
 
-            main_ax = self.get_main_ax()
-            for plan in self._get_layers_zorder():
-                plan.render(main_ax)
-        except Exception as e:
-            raise Exception(f"An error occur during rendering of {plan}") from e
+        main_ax = self.get_main_ax()
+        for plan in self._get_layers_zorder():
+            _render_with_context(plan, main_ax)
 
     def add_layer(self, plot: RenderPlan, zorder=None, name=None, legend=True):
         """Add a plotter to the main canvas
@@ -560,6 +578,8 @@ class WhiteBoard(LegendMaker):
             msg = f"{plot_type} cannot be rendered as another layer."
             raise TypeError(msg)
         self._check_layer_conflict(plot)
+        check_plot_data(plot, "main", plot.data_axis("main"), self._board_shape())
+        plot._added_at = caller_location()
         if zorder is not None:
             plot.zorder = zorder
         plot.set(name=name)
@@ -1119,6 +1139,16 @@ class ClusterBoard(WhiteBoard):
         cluster_data = np.asarray(densify(cluster_data))
         if cluster_data.ndim != 2:
             raise ValueError("Cluster data must be 2D array")
+        if cluster_data.dtype.kind in "US":
+            # Text reaches numpy's reductions and dies as a ufunc loop error
+            # that names neither marsilea nor the data.
+            msg = (
+                f"{self.__class__.__name__} needs numbers, but this data is "
+                f"text (dtype {cluster_data.dtype}). Use `ma.CatHeatmap` for "
+                f"categories, or pass `cluster_data=` to cluster on something "
+                f"numeric."
+            )
+            raise ValueError(msg)
         self._cluster_data = cluster_data
         self._deform = Deformation(cluster_data)
 
@@ -1573,19 +1603,16 @@ class ClusterBoard(WhiteBoard):
 
     def _render_plan(self):
         deform = self.get_deform()
-        try:
-            for plan in self._col_plan + self._row_plan:
-                if plan.allow_split:
-                    plan.set_deform(deform)
-                axes = self.layout.get_ax(plan.name)
-                plan.render(axes)
-
-            main_ax = self.get_main_ax()
-            for plan in self._get_layers_zorder():
+        for plan in self._col_plan + self._row_plan:
+            if plan.allow_split:
                 plan.set_deform(deform)
-                plan.render(main_ax)
-        except Exception as e:
-            raise Exception(f"An error occurred during rendering of {plan}") from e
+            axes = self.layout.get_ax(plan.name)
+            _render_with_context(plan, axes)
+
+        main_ax = self.get_main_ax()
+        for plan in self._get_layers_zorder():
+            plan.set_deform(deform)
+            _render_with_context(plan, main_ax)
 
     def get_deform(self):
         """Return the deformation object of the cluster data"""

--- a/src/marsilea/layout.py
+++ b/src/marsilea/layout.py
@@ -394,7 +394,19 @@ class CrossLayout(_MarginMixin):
                 self._side_cells[side].remove(pad)
 
     def get_ax(self, name):
-        return self.cells[name].ax
+        cell = self.cells.get(name)
+        if cell is None:
+            # The main cell is keyed by an internal name nobody types; point at
+            # get_main_ax() rather than print a uuid.
+            named = [n for n, c in self.cells.items() if c is not self.main_cell]
+            has = ", ".join(repr(n) for n in named) if named else "none"
+            raise KeyError(
+                f"No axes named {name!r}. Named axes on this board: {has}. "
+                f"The main canvas is `get_main_ax()`."
+            )
+        if cell.ax is None:
+            raise KeyError(f"{name!r} has no axes yet, call `render()` first.")
+        return cell.ax
 
     def get_main_ax(self):
         return self.main_cell.ax

--- a/src/marsilea/plotter/base.py
+++ b/src/marsilea/plotter/base.py
@@ -299,6 +299,8 @@ class RenderPlan:
     _plan_label: RenderPlanLabel = None
     _split_regroup: Sequence[float] = None
     _registered: bool = False
+    #: ``file:line`` of the ``add_*`` call, for render-time errors.
+    _added_at: str = None
 
     def __new__(cls, *args, **kwargs):
         """Defer construction when the data is an unresolved reference.
@@ -345,14 +347,24 @@ class RenderPlan:
         self.label = label
         self._plan_label = RenderPlanLabel(label, loc=loc, props=props)
 
+    def data_axis(self, side=None):
+        """Which board axis this plan's data indexes: 'row', 'col' or 'main'.
+
+        `side` overrides ``self.side``, so a board can ask the question before
+        it has committed to adding the plotter.
+        """
+        side = self.side if side is None else side
+        if side == "main":
+            return "main"
+        return "row" if side in ("left", "right") else "col"
+
     def get_deform_func(self):
         if self.has_deform:
-            if self.side == "main":
-                return self.deform.transform
-            elif self.is_flank:
-                return self.deform.transform_row
-            else:
-                return self.deform.transform_col
+            return {
+                "main": self.deform.transform,
+                "row": self.deform.transform_row,
+                "col": self.deform.transform_col,
+            }[self.data_axis()]
 
     def reindex_by_chunk(self, group_data):
         if group_data is not None:
@@ -476,16 +488,13 @@ class RenderPlan:
         return RenderSpec(ax=ax, data=spec_data, params=params)
 
     def get_render_spec(self, axes):
-        try:
-            if self.is_split:
-                return self._get_split_render_spec(axes)
-            else:
-                return self._get_intact_render_spec(axes)
-        except Exception as _:
-            raise DataError(
-                f"Please check your data input "
-                f"with {self.__class__.__name__} at '{self.side}'"
-            )
+        # Deformation raises precise messages here ("Data has 7 elements on the
+        # row axis, expected 10"). Catching them to say "check your data" threw
+        # away the only part worth reading; the board adds the plotter and its
+        # call site as notes instead.
+        if self.is_split:
+            return self._get_split_render_spec(axes)
+        return self._get_intact_render_spec(axes)
 
     @property
     def has_deform(self):
@@ -608,6 +617,11 @@ class StatsBase(RenderPlan):
             return "h" if self.is_flank else "v"
         return self.orient
 
+    def data_axis(self, side=None):
+        side = self.side if side is None else side
+        orient = self.orient or ("h" if side in ("left", "right") else "v")
+        return "col" if orient == "v" else "row"
+
     def get_deform_func(self):
         if self.has_deform:
             orient = self.get_orient()
@@ -624,10 +638,9 @@ class StatsBase(RenderPlan):
                     )
                     raise SplitConflict(msg)
 
-            if self.get_orient() == "v":
+            if self.data_axis() == "col":
                 return self.deform.transform_col
-            else:
-                return self.deform.transform_row
+            return self.deform.transform_row
 
     def _setup_axis(self, ax):
         if self.get_orient() == "h":

--- a/src/marsilea/plotter/text.py
+++ b/src/marsilea/plotter/text.py
@@ -1139,8 +1139,11 @@ class Chunk(_ChunkBase):
             axes = [axes]
 
         if len(axes) != self.n:
+            axis = "rows" if self.is_flank else "columns"
             raise ValueError(
-                f"You have {len(axes)} axes but you only provide {self.n} texts."
+                f"`{type(self).__name__}` on '{self.side}' has {self.n} labels "
+                f"but the {axis} are in {len(axes)} groups. Give one label per "
+                f"group, in the same order as `group_{axis[:-1]}s`."
             )
 
         texts = self.reindex_by_chunk(self.texts)
@@ -1271,8 +1274,11 @@ class FixedChunk(_ChunkBase):
             axes = [axes]
 
         if len(axes) != self.n:
+            axis = "rows" if self.is_flank else "columns"
             raise ValueError(
-                f"You have {len(axes)} axes but you only provide {self.n} texts."
+                f"`{type(self).__name__}` on '{self.side}' has {self.n} labels "
+                f"but the {axis} are in {len(axes)} groups. Give one label per "
+                f"group, in the same order as `group_{axis[:-1]}s`."
             )
 
         self._render(

--- a/src/marsilea/utils.py
+++ b/src/marsilea/utils.py
@@ -1,8 +1,19 @@
+import os
+import re
+import sys
+
 import matplotlib as mpl
 import numpy as np
 from itertools import tee, islice
 from matplotlib import colors as mcolors
 from uuid import uuid4
+
+#: Everything under here is marsilea's own code, so it is never the caller.
+_PKG_DIR = os.path.dirname(os.path.abspath(__file__))
+
+#: marimo compiles a cell from a temp file with the cell id in its name. Same
+#: rule marimo reads it back with, kept here so nothing has to import marimo.
+_MARIMO_CELL = re.compile(r"^__marimo__cell_(.*?)_")
 
 ECHARTS16 = [
     "#5470c6",
@@ -115,3 +126,47 @@ def _check_side(side):
     options = ["top", "bottom", "left", "right"]
     if side not in options:
         raise ValueError(f"`side` must be one of {options}.")
+
+
+def _notebook_location(filename, lineno):
+    """``Cell In[3]:12`` or ``marimo cell Hbol:12``, or None for a real file.
+
+    A notebook compiles every cell from a throwaway path such as
+    ``/tmp/ipykernel_913/2179451630.py``, which tells the reader nothing about
+    where to go and look. Jupyter knows the execution count behind that path,
+    and marimo writes the cell id into the name, so both can do better.
+    """
+    # Probe sys.modules rather than import, the way marsilea._sources detects
+    # its data containers. No shell running means no cells can exist.
+    ipython = sys.modules.get("IPython")
+    if ipython is not None:
+        try:
+            label = ipython.get_ipython().compile.format_code_name(filename)
+        except Exception:
+            # Naming a frame is a nicety, never let it replace the real error.
+            label = None
+        if label is not None:
+            kind, name = label
+            return f"{kind} {name}:{lineno}"
+
+    cell = _MARIMO_CELL.match(os.path.basename(filename))
+    if cell is not None:
+        return f"marimo cell {cell.group(1)}:{lineno}"
+    return None
+
+
+def caller_location():
+    """Where the caller is, as ``file:line`` or ``Cell In[3]:12``, or None.
+
+    A board is built lazily, so a plotter that fails at render was added
+    somewhere the traceback never mentions. Recording the ``add_*`` call site
+    is what lets the render-time error point back at it.
+    """
+    frame = sys._getframe(1)
+    while frame is not None:
+        filename = frame.f_code.co_filename
+        if not filename.startswith(_PKG_DIR):
+            lineno = frame.f_lineno
+            return _notebook_location(filename, lineno) or f"{filename}:{lineno}"
+        frame = frame.f_back
+    return None

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,293 @@
+"""What the user sees when they get something wrong.
+
+Marsilea builds lazily, so a mistake made at ``add_left`` used to surface at
+``render`` with the real message swallowed and the offending line nowhere in
+the traceback. These tests pin down the two halves of the fix: mismatches that
+can be caught at the ``add_*`` call are caught there, and everything else keeps
+its own error and gains a pointer back to where the plotter came from.
+"""
+
+import sys
+
+import numpy as np
+import pytest
+
+import marsilea as ma
+import marsilea.plotter as mp
+from marsilea.utils import caller_location, _notebook_location
+
+
+@pytest.fixture
+def data():
+    return np.random.RandomState(0).randn(10, 8)
+
+
+# --- caught at the add_* call --------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "side,expect",
+    [
+        ("left", "10 rows"),
+        ("right", "10 rows"),
+        ("top", "8 columns"),
+        ("bottom", "8 columns"),
+    ],
+)
+def test_wrong_length_is_rejected_where_it_is_added(data, side, expect):
+    h = ma.Heatmap(data)
+    with pytest.raises(ValueError, match=f"`Numbers` on '{side}'.*{expect}"):
+        h.add_plot(side, mp.Numbers(np.arange(3)))
+
+
+def test_layer_shape_is_rejected_where_it_is_added(data):
+    h = ma.Heatmap(data)
+    with pytest.raises(ValueError, match=r"`ColorMesh` has shape \(5, 5\)"):
+        h.add_layer(mp.ColorMesh(np.random.rand(5, 5)))
+
+
+def test_length_of_the_other_axis_suggests_the_other_side(data):
+    h = ma.Heatmap(data)
+    with pytest.raises(ValueError, match="try `add_top` or `add_bottom`"):
+        h.add_left(mp.Numbers(np.arange(8)))
+
+    h = ma.Heatmap(data)
+    with pytest.raises(ValueError, match="try `add_left` or `add_right`"):
+        h.add_top(mp.Numbers(np.arange(10)))
+
+
+def test_a_length_that_fits_nothing_explains_the_convention(data):
+    h = ma.Heatmap(data)
+    with pytest.raises(ValueError, match="one value per row"):
+        h.add_left(mp.Numbers(np.arange(3)))
+
+
+def test_transposed_layer_is_named_as_such(data):
+    h = ma.Heatmap(data)
+    with pytest.raises(ValueError, match=r"looks transposed, try `data\.T`"):
+        h.add_layer(mp.ColorMesh(np.random.rand(8, 10)))
+
+
+def test_a_pinned_orient_does_not_suggest_moving_the_plot(data):
+    # Violin(orient="h") reads its data along rows wherever it is put, so
+    # "try the other side" would be wrong advice.
+    h = ma.Heatmap(data)
+    with pytest.raises(ValueError, match="orient='h' reads values along rows") as err:
+        h.add_top(mp.Violin(np.random.rand(4, 8), orient="h"))
+    assert "try `add_" not in str(err.value)
+
+
+def test_a_rejected_plot_leaves_the_board_usable(data):
+    h = ma.Heatmap(data)
+    with pytest.raises(ValueError):
+        h.add_left(mp.Numbers(np.arange(3)))
+    # No orphan axes left in the layout by the failed add.
+    h.add_left(mp.Numbers(np.arange(10)))
+    h.render()
+
+
+# --- and what must NOT be rejected ----------------------------------------
+
+
+def test_correct_data_is_accepted_on_every_side(data):
+    h = ma.Heatmap(data)
+    h.add_left(mp.Numbers(np.arange(10)))
+    h.add_top(mp.Numbers(np.arange(8)))
+    h.add_layer(mp.MarkerMesh(data > 1, color="red"))
+    h.render()
+
+
+def test_seaborn_plotters_follow_their_orientation(data):
+    h = ma.Heatmap(data)
+    h.add_left(mp.Violin(np.random.rand(4, 10)))
+    h.add_top(mp.Violin(np.random.rand(4, 8)))
+    h.render()
+
+
+def test_plotters_without_deformable_data_are_left_alone(data):
+    h = ma.Heatmap(data)
+    h.group_rows(["a"] * 5 + ["b"] * 5)
+    h.add_right(mp.Chunk(["a", "b"]))  # counted per group, not per row
+    h.add_title(top="a title")  # allow_split = False, never deformed
+    h.render()
+
+
+def test_a_board_without_a_grid_is_not_checked():
+    wb = ma.WhiteBoard(width=3, height=3)
+    wb.add_left(mp.Numbers(np.arange(4)))
+    wb.add_top(mp.Numbers(np.arange(7)))
+    wb.render()
+
+
+# --- render-time failures keep their own error ----------------------------
+
+
+def _chunk_board(data):
+    h = ma.Heatmap(data)
+    h.group_rows(["a"] * 5 + ["b"] * 5)
+    h.add_right(mp.Chunk(["a", "b", "c"]))
+    return h
+
+
+def test_render_error_keeps_its_type_and_message(data):
+    # Regression: this used to be re-wrapped into a bare Exception whose
+    # message was the plotter's repr, discarding the real one.
+    with pytest.raises(ValueError, match="has 3 labels but the rows are in 2 groups"):
+        _chunk_board(data).render()
+
+
+def test_render_error_names_the_plotter_and_its_call_site(data):
+    h = _chunk_board(data)
+    with pytest.raises(ValueError) as err:
+        h.render()
+    notes = "\n".join(err.value.__notes__)
+    assert "while rendering Chunk on 'right'" in notes
+    assert "added at" in notes
+    assert __file__ in notes
+
+
+def test_a_deformation_mismatch_reaches_the_caller_intact(data):
+    # Reach past add_plot's check to prove the render path no longer swallows
+    # the message Deformation raises.
+    h = ma.Heatmap(data)
+    plot = mp.Numbers(np.arange(10))
+    h.add_left(plot)
+    plot.set_data(np.arange(3))
+    with pytest.raises(ValueError, match="3 elements on the row axis, expected 10"):
+        h.render()
+
+
+# --- the other messages ---------------------------------------------------
+
+
+def test_text_data_points_at_the_categorical_heatmap():
+    with pytest.raises(ValueError, match="needs numbers.*CatHeatmap"):
+        ma.Heatmap(np.array([["a"] * 8] * 10))
+
+
+def test_categorical_heatmap_still_takes_text():
+    ma.CatHeatmap(np.array([["a", "b"], ["b", "a"]])).render()
+
+
+def test_unknown_axes_name_lists_the_real_ones(data):
+    h = ma.Heatmap(data)
+    h.add_left(mp.Numbers(np.arange(10)), name="bars")
+    h.render()
+    with pytest.raises(KeyError, match="No axes named 'nope'.*Named axes.*bars"):
+        h.get_ax("nope")
+
+
+def test_asking_for_an_axes_before_render_says_so(data):
+    h = ma.Heatmap(data)
+    h.add_left(mp.Numbers(np.arange(10)), name="bars")
+    with pytest.raises(KeyError, match="has no axes yet, call `render"):
+        h.get_ax("bars")
+
+
+def test_cut_outside_the_data_is_rejected(data):
+    with pytest.raises(
+        ValueError, match=r"Cannot cut rows at \[99\], there are only 10 rows"
+    ):
+        ma.Heatmap(data).cut_rows([99])
+    with pytest.raises(
+        ValueError, match=r"Cannot cut columns at \[99\], there are only 8 columns"
+    ):
+        ma.Heatmap(data).cut_cols([99])
+    with pytest.raises(ValueError, match="Cuts go between 1 and 9"):
+        ma.Heatmap(data).cut_rows([0])
+
+
+def test_repeated_cut_is_rejected(data):
+    with pytest.raises(ValueError, match=r"Cannot cut rows at \[4\] twice"):
+        ma.Heatmap(data).cut_rows([4, 4])
+
+
+def test_valid_cuts_and_groups_still_split(data):
+    h = ma.Heatmap(data)
+    h.cut_rows([4])
+    h.render()
+
+    h = ma.Heatmap(data)
+    h.group_rows(["a"] * 5 + ["b"] * 5)
+    h.render()
+
+
+# --- where the call site points, per environment --------------------------
+
+
+class _FakeCompiler:
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    def format_code_name(self, name):
+        number = self.mapping.get(name)
+        return None if number is None else ("Cell", f"In[{number}]")
+
+
+class _FakeIPython:
+    """Just enough of the IPython module for `_notebook_location`."""
+
+    def __init__(self, shell):
+        self._shell = shell
+
+    def get_ipython(self):
+        return self._shell
+
+
+class _FakeShell:
+    def __init__(self, mapping):
+        self.compile = _FakeCompiler(mapping)
+
+
+def _fake_ipython(monkeypatch, shell):
+    monkeypatch.setitem(sys.modules, "IPython", _FakeIPython(shell))
+
+
+def test_a_notebook_cell_is_named_by_its_execution_count(monkeypatch):
+    _fake_ipython(monkeypatch, _FakeShell({"/tmp/ipykernel_9/12345.py": 3}))
+    assert _notebook_location("/tmp/ipykernel_9/12345.py", 12) == "Cell In[3]:12"
+
+
+def test_a_real_file_keeps_its_path(monkeypatch):
+    _fake_ipython(monkeypatch, _FakeShell({}))
+    assert _notebook_location("/home/me/plot.py", 12) is None
+
+
+def test_no_shell_running_falls_back_to_the_path(monkeypatch):
+    _fake_ipython(monkeypatch, None)  # IPython imported, but not a shell
+    assert _notebook_location("/tmp/ipykernel_9/12345.py", 12) is None
+
+
+def test_an_unexpected_ipython_never_breaks_the_error(monkeypatch):
+    class Exploding:
+        @property
+        def compile(self):
+            raise RuntimeError("IPython changed shape")
+
+    _fake_ipython(monkeypatch, Exploding())
+    assert _notebook_location("/tmp/ipykernel_9/12345.py", 12) is None
+
+
+def test_a_marimo_cell_is_named_by_its_cell_id(monkeypatch):
+    _fake_ipython(monkeypatch, None)
+    location = _notebook_location("/tmp/marimo_17/__marimo__cell_Hbol_.py", 3)
+    assert location == "marimo cell Hbol:3"
+
+
+def test_marimo_running_a_notebook_file_keeps_the_path(monkeypatch):
+    # marimo notebooks are real .py files; when it runs one the frame already
+    # points somewhere the reader can open.
+    _fake_ipython(monkeypatch, None)
+    assert _notebook_location("/home/me/analysis.py", 3) is None
+
+
+def test_caller_location_reports_this_file_outside_a_notebook():
+    location = caller_location()
+    assert location.startswith(__file__)
+
+
+def test_ipython_still_offers_the_api_the_cell_name_relies_on():
+    # A contract test: if IPython drops or renames this, the call site quietly
+    # degrades to a temp path, which is the whole thing worth avoiding.
+    compilerop = pytest.importorskip("IPython.core.compilerop")
+    assert hasattr(compilerop.CachingCompiler, "format_code_name")


### PR DESCRIPTION
## The problem

Boards are built lazily, so every data check runs at `render()`, far from the line that got it wrong. Two blanket `except Exception` blocks then discarded the one useful thing in the error.

`Deformation` already raises precise messages. [`RenderPlan.get_render_spec`](https://github.com/Marsilea-viz/marsilea/blob/main/src/marsilea/plotter/base.py#L478) caught them all and substituted `DataError("Please check your data input with Numbers at 'left'")`, dropping the original entirely (`except Exception as _`, no `from e`). `_render_plan` then re-wrapped that into a bare `Exception` whose message was the plotter's repr. Python prints the outermost exception last, so **the final line the user read was the only one that said nothing**:

```
Exception: An error occurred during rendering of Numbers(name='Numbers-left-14b38e4c060e4ef1b8264da08109cddb', side='left', zorder=0)
```

39 traceback frames, and the user's own `add_left(...)` line appeared in none of them.

`check_length` in `_normalize.py` already fixed this for the AnnData reference path, and its docstring names the problem: *"Catches the mismatch where it happens instead of at render, where the error `Deformation` raises is swallowed twice before it reaches the caller."* The plain-array path, which is most usage, had no such check.

## After

```
ValueError: `Numbers` on 'left' has 12 values, but there are 10 rows. There are 12 columns, so try `add_top` or `add_bottom` instead.
```

Five frames, and the first is the caller's `add_left`.

## What changed

**Stop discarding the real error.** The blanket `except` in `get_render_spec` is gone. Both `_render_plan` implementations route each plan through `_render_with_context`, which uses `Exception.add_note` (3.11+, and the project already requires 3.11) so the original type, message and traceback all survive and gain two lines of context:

```
ValueError: `Chunk` on 'right' has 3 labels but the rows are in 2 groups. Give one label per group, in the same order as `group_rows`.
  while rendering Chunk on 'right'
  added at Cell In[2]:3
```

This also removes a latent bug: the old `except` read the loop variable `plan`, which is unbound if `get_main_ax()` raises with no side plans, masking the real error with `NameError`.

**Check shapes when the plotter is added.** `check_plot_data` runs from `add_plot` and `add_layer`, before the layout is touched, so a rejected plot leaves no orphan axes behind. To keep it from ever being stricter than the render, the "which axis does this data index" decision moved into `RenderPlan.data_axis`, and `get_deform_func` now dispatches on that same method. A length matching the other axis is called out, since that is nearly always a plot put on the wrong side.

**Record the call site.** Under Jupyter and marimo a cell compiles from a throwaway path such as `/tmp/ipykernel_913/2179451630.py`, which tells the reader nothing, so those are resolved to `Cell In[3]:12` and `marimo cell Hbol:12`. Both lookups are guarded: if either tool changes shape, the note falls back to the raw path and the underlying error is untouched. Nothing imports IPython or marimo; `sys.modules` is probed, the way `_sources.py` already detects its data containers.

**Four other messages**, each reproduced against `main`:

| | before | after |
|---|---|---|
| text into `Heatmap` | `_UFuncNoLoopError: ufunc 'fmin' did not contain a loop with signature matching types (dtype('<U1'), ...)` | `Heatmap needs numbers, but this data is text (dtype <U1). Use ma.CatHeatmap for categories, or pass cluster_data= to cluster on something numeric.` |
| `get_ax('typo')` | `KeyError: 'typo'` | `No axes named 'typo'. Named axes on this board: 'bars'. The main canvas is get_main_ax().` |
| `cut_rows([99])` on 10 rows | **no error at all**, silently wrong | `Cannot cut rows at [99], there are only 10 rows. Cuts go between 1 and 9.` |
| `Chunk` label count | `You have 2 axes but you only provide 3 texts.` | `Chunk on 'right' has 3 labels but the rows are in 2 groups. Give one label per group, in the same order as group_rows.` |

## Verification

The risk here is the add-time check rejecting something the render accepts, so it was dry-run first, recording instead of raising, across the whole suite and the example scripts: **zero false positives**.

- `672 passed, 6 xfailed` before, `672 passed, 6 xfailed` after excluding the new tests. No regressions.
- `704 passed` with the 32 new tests in `tests/test_errors.py`.

Notes render in every environment checked, each tested rather than assumed, since display depends on the traceback formatter rather than on `add_note` itself:

| environment | call site reads |
|---|---|
| script, pytest | `/path/plot.py:14` |
| IPython terminal | `Cell In[1]:3` |
| Jupyter (real ipykernel) | `Cell In[2]:3` |
| marimo, notebook as script | `/path/nb.py:16` |
| marimo interactive kernel | `marimo cell Hbol:3` |

marimo formats through stdlib `traceback`, including its short-message path, which keeps notes via `format_exception_only`; verified against marimo's own renderer, not only a script run.

No new public API and no changes to `exceptions.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
