### PR TITLE
fix: point the Chunk error at group_cols, which exists

### DIFF
--- a/src/marsilea/_deform.py
+++ b/src/marsilea/_deform.py
@@ -192,7 +192,8 @@ class Deformation:
                 f"Cannot cut {unit}s at {outside}, there are only {n} {unit}s. "
                 f"Cuts go between 1 and {n - 1}."
             )
-        repeated = sorted({int(c) for c in cuts if list(cuts).count(c) > 1})
+        values, counts = np.unique(cuts, return_counts=True)
+        repeated = [int(v) for v in values[counts > 1]]
         if repeated:
             raise ValueError(
                 f"Cannot cut {unit}s at {repeated} twice, "

--- a/src/marsilea/plotter/text.py
+++ b/src/marsilea/plotter/text.py
@@ -1139,11 +1139,15 @@ class Chunk(_ChunkBase):
             axes = [axes]
 
         if len(axes) != self.n:
-            axis = "rows" if self.is_flank else "columns"
+            # Spell the method out. Deriving it from the word above produced
+            # `group_columns`, which does not exist.
+            axis, grouper = (
+                ("rows", "group_rows") if self.is_flank else ("columns", "group_cols")
+            )
             raise ValueError(
                 f"`{type(self).__name__}` on '{self.side}' has {self.n} labels "
                 f"but the {axis} are in {len(axes)} groups. Give one label per "
-                f"group, in the same order as `group_{axis[:-1]}s`."
+                f"group, in the same order as `{grouper}`."
             )
 
         texts = self.reindex_by_chunk(self.texts)
@@ -1274,11 +1278,15 @@ class FixedChunk(_ChunkBase):
             axes = [axes]
 
         if len(axes) != self.n:
-            axis = "rows" if self.is_flank else "columns"
+            # Spell the method out. Deriving it from the word above produced
+            # `group_columns`, which does not exist.
+            axis, grouper = (
+                ("rows", "group_rows") if self.is_flank else ("columns", "group_cols")
+            )
             raise ValueError(
                 f"`{type(self).__name__}` on '{self.side}' has {self.n} labels "
                 f"but the {axis} are in {len(axes)} groups. Give one label per "
-                f"group, in the same order as `group_{axis[:-1]}s`."
+                f"group, in the same order as `{grouper}`."
             )
 
         self._render(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -7,6 +7,7 @@ can be caught at the ``add_*`` call are caught there, and everything else keeps
 its own error and gains a pointer back to where the plotter came from.
 """
 
+import re
 import sys
 
 import numpy as np
@@ -134,6 +135,24 @@ def test_render_error_keeps_its_type_and_message(data):
     # message was the plotter's repr, discarding the real one.
     with pytest.raises(ValueError, match="has 3 labels but the rows are in 2 groups"):
         _chunk_board(data).render()
+
+
+@pytest.mark.parametrize(
+    "side,grouper", [("right", "group_rows"), ("top", "group_cols")]
+)
+def test_chunk_names_the_grouping_method_that_exists(data, side, grouper):
+    # The message used to build the name out of the word "columns" and land on
+    # `group_columns`, sending the reader to a method that is not there.
+    h = ma.Heatmap(data)
+    if side == "right":
+        h.group_rows(["a"] * 5 + ["b"] * 5)
+    else:
+        h.group_cols(["a"] * 4 + ["b"] * 4)
+    h.add_plot(side, mp.Chunk(["a", "b", "c"]))
+    with pytest.raises(ValueError, match=f"`{grouper}`") as err:
+        h.render()
+    named = re.search(r"`(group_\w+)`", str(err.value)).group(1)
+    assert hasattr(ma.Heatmap, named), f"error points at {named}, which does not exist"
 
 
 def test_render_error_names_the_plotter_and_its_call_site(data):


### PR DESCRIPTION
Follow-up to #110, which I merged before its review landed. Both points came from Copilot; I evaluated each rather than taking them as given.

## 1. The error named a method that does not exist (worth fixing)

The label-count message derived the method name from the word it had just printed:

```python
axis = "rows" if self.is_flank else "columns"
... f"in the same order as `group_{axis[:-1]}s`."
```

On rows that yields `group_rows`. On columns it yields `group_columns`, and the API is [`group_cols`](https://github.com/Marsilea-viz/marsilea/blob/main/src/marsilea/base.py#L1413). So a `Chunk` on top or bottom sent the reader to a method that is not there:

```
before:  `Chunk` on 'top' has 3 labels but the columns are in 2 groups.
         Give one label per group, in the same order as `group_columns`.   <- does not exist

after:   `Chunk` on 'top' has 3 labels but the columns are in 2 groups.
         Give one label per group, in the same order as `group_cols`.
```

That is precisely the failure #110 set out to remove, so it earns the fix. Both names are now written out rather than computed.

I audited every other identifier the new messages mention (`add_top`/`add_bottom`/`add_left`/`add_right`, `ma.CatHeatmap`, `mp.Colors`, `cluster_data=`, `get_main_ax`, `get_plot_names`, `render`, `group_rows`): `group_columns` was the only broken one.

The new test follows whichever method the message names and asserts the board actually has it, so a future rename fails loudly instead of silently misdirecting:

```python
named = re.search(r"`(group_\w+)`", str(err.value)).group(1)
assert hasattr(ma.Heatmap, named), f"error points at {named}, which does not exist"
```

## 2. `list(cuts).count(c)` in a comprehension (taken, but not for the stated reason)

```python
-        repeated = sorted({int(c) for c in cuts if list(cuts).count(c) > 1})
+        values, counts = np.unique(cuts, return_counts=True)
+        repeated = [int(v) for v in values[counts > 1]]
```

The O(n²) claim is accurate, but `cuts` holds the cut positions of a heatmap, so n is single digits and the quadratic term buys nothing. Rebuilding a list inside the comprehension was just poor code, and `np.unique` on an array that is already a numpy array is shorter and clearer. Taking it as a readability change, not a performance one.

Output is unchanged, order included, since `np.unique` returns sorted values:

```
[4, 4]       -> Cannot cut rows at [4] twice, that would leave an empty group.
[3, 3, 7, 7] -> Cannot cut rows at [3, 7] twice, that would leave an empty group.
[2, 5]       -> ok
[99]         -> Cannot cut rows at [99], there are only 10 rows. Cuts go between 1 and 9.
```

## Verification

`706 passed, 6 xfailed` (704 from #110 plus the two new parametrised cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
