### PR TITLE
fix: NaN padding, warning stacklevels, and Zero* data sources

### DIFF
--- a/docs/source/tutorial/stats_annotation.rst
+++ b/docs/source/tutorial/stats_annotation.rst
@@ -205,6 +205,38 @@ with a warning telling you what to pass.
     >>> h.render()
 
 
+Groups of unequal size
+----------------------
+
+Wide input has to be rectangular, and real groups rarely are. Pad the short
+ones with :code:`NaN`; pandas does it for you and keeps the column labels that
+name the pairs::
+
+    pd.DataFrame({"A": pd.Series(a), "B": pd.Series(b)})
+
+Padding is not data. It stays out of the plot and out of the test, so a group
+of 8 is tested as 8 values.
+
+If a group has nothing left to test, there is no p-value and no label. The
+bracket is still drawn, and a warning names the pair, because an empty label
+is easy to miss on a finished figure.
+
+.. plot::
+    :context: close-figs
+
+    >>> sizes = [30, 12, 30, 8, 30, 30]
+    >>> ragged = pd.DataFrame(
+    ...     {g: pd.Series(np.random.normal(4, 1, n)) for g, n in zip(genes, sizes)}
+    ... )
+    >>> box = mp.Box({"Control": ragged, "Treated": treated}, label="Expression")
+    >>> box.annotate_stats(pairs="hue", text_format="star")
+    >>> h = ma.Heatmap(treated.values - control.values, label="Difference")
+    >>> h.add_top(box, size=2, pad=0.1)
+    >>> h.add_bottom(mp.Labels(genes))
+    >>> h.add_legends()
+    >>> h.render()
+
+
 Orientation
 -----------
 

--- a/src/marsilea/_deform.py
+++ b/src/marsilea/_deform.py
@@ -5,7 +5,7 @@ from typing import Any, Mapping
 import numpy as np
 
 from .dendrogram import Dendrogram, GroupDendrogram
-from .utils import pairwise
+from .utils import find_stack_level, pairwise
 
 _ROW, _COL = 0, 1
 
@@ -428,7 +428,7 @@ class Deformation:
             f"Deformation.{name} is an internal helper and will be removed, "
             f"use {instead} instead",
             DeprecationWarning,
-            stacklevel=3,
+            stacklevel=find_stack_level(),
         )
 
     def split_by_row(self, data: np.ndarray):

--- a/src/marsilea/_normalize.py
+++ b/src/marsilea/_normalize.py
@@ -19,6 +19,7 @@ import warnings
 import numpy as np
 
 from .exceptions import PerformanceWarning
+from .utils import find_stack_level
 
 # Densifying above this many cells is worth warning about: a 30k x 20k matrix is
 # ~4.8 GB dense, and add_dendrogram then runs a scipy linkage over it.
@@ -49,7 +50,7 @@ def densify(arr):
             f"Converting a sparse {arr.shape} array to dense uses about "
             f"{size * 8 / 1e9:.1f} GB. Subset the data before plotting it.",
             PerformanceWarning,
-            stacklevel=4,
+            stacklevel=find_stack_level(),
         )
     return arr.toarray()
 

--- a/src/marsilea/_sources.py
+++ b/src/marsilea/_sources.py
@@ -51,6 +51,7 @@ import pandas as pd
 
 from ._normalize import check_length, to_array
 from .exceptions import MisalignedRef
+from .utils import find_stack_level
 
 #: Which board axis each container axis maps to. Keyed by *container* axis name.
 AXIS_MAP_DEFAULT = {"obs": "row", "var": "col"}
@@ -327,7 +328,7 @@ def accepts_source(init):
                 "obs_axis has no effect without a data source; pass one, e.g. "
                 '`ma.Heatmap(adata, A.X[:, :], obs_axis="col")`.',
                 UserWarning,
-                stacklevel=2,
+                stacklevel=find_stack_level(),
             )
         if source is not None:
             self._source = source

--- a/src/marsilea/base.py
+++ b/src/marsilea/base.py
@@ -874,6 +874,7 @@ class ZeroWidth(WhiteBoard):
 
     """
 
+    @accepts_source
     def __init__(self, height, name=None, margin=0.2):
         super().__init__(
             width=0, height=height, name=name, margin=margin, init_main=False
@@ -888,6 +889,7 @@ class ZeroHeight(WhiteBoard):
 
     """
 
+    @accepts_source
     def __init__(self, width, name=None, margin=0.2):
         super().__init__(
             width=width, height=0, name=name, margin=margin, init_main=False
@@ -1683,6 +1685,7 @@ class ZeroWidthCluster(ClusterBoard):
 
     """
 
+    @accepts_source
     def __init__(self, cluster_data, height, name=None, margin=0.2):
         super().__init__(
             cluster_data=cluster_data,
@@ -1713,6 +1716,7 @@ class ZeroHeightCluster(ClusterBoard):
 
     """
 
+    @accepts_source
     def __init__(self, cluster_data, width, name=None, margin=0.2):
         super().__init__(
             cluster_data=cluster_data,

--- a/src/marsilea/dendrogram.py
+++ b/src/marsilea/dendrogram.py
@@ -9,6 +9,7 @@ from scipy.cluster.hierarchy import linkage as scipy_linkage, dendrogram
 from typing import List
 
 from .exceptions import PerformanceWarning
+from .utils import find_stack_level
 
 _FASTCLUSTER_THRESHOLD = 10_000  # total elements; matches seaborn
 
@@ -38,7 +39,7 @@ def _compute_linkage(data, method, metric):
                 "Install `fastcluster` for better performance: "
                 "pip install marsilea[fast]",
                 PerformanceWarning,
-                stacklevel=4,
+                stacklevel=find_stack_level(),
             )
         return scipy_linkage(data, method=method, metric=metric)
 

--- a/src/marsilea/plotter/_seaborn.py
+++ b/src/marsilea/plotter/_seaborn.py
@@ -18,7 +18,7 @@ from ._stats_annot import (
     undodged_pairs,
 )
 from .base import StatsBase
-from ..utils import ECHARTS16
+from ..utils import ECHARTS16, find_stack_level
 
 
 def _extract_names(data):
@@ -296,7 +296,7 @@ class _SeabornBase(StatsBase):
                 f"{len(overlaid)} pair(s) compare hue levels that are drawn at the "
                 f"same place; pass dodge=True to separate them: "
                 f"{sorted(overlaid, key=str)}",
-                stacklevel=4,
+                stacklevel=find_stack_level(),
             )
             overlaid = set(map(str, overlaid))
             brackets = [b for b in brackets if str(b.original) not in overlaid]
@@ -319,7 +319,7 @@ class _SeabornBase(StatsBase):
             warnings.warn(
                 f"{len(unknown)} pair(s) name a category that is not in the data "
                 f"and were skipped: {sorted(unknown, key=str)}",
-                stacklevel=4,
+                stacklevel=find_stack_level(),
             )
 
     def render(self, axes):
@@ -384,6 +384,13 @@ def _seaborn_doc(obj: _SeabornBase):
         You can only use wide-format for this plot, the number of columns
         of your input data should match your main data, this allow the data
         to be split and reorder if split and cluster is applied.
+
+        The number of rows is up to you. Rows are the observations, and
+        nothing is aligned to them, so groups of unequal size can be padded
+        with :code:`NaN` to keep the input rectangular. Padding stays out of
+        the plot and out of the tests::
+
+            pd.DataFrame({{'A': pd.Series(a), 'B': pd.Series(b)}})
         
     
     Parameters

--- a/src/marsilea/plotter/_stats_annot.py
+++ b/src/marsilea/plotter/_stats_annot.py
@@ -399,6 +399,15 @@ def flatten(per_chunk, cross, hue_order):
 # --- statistics ------------------------------------------------------------
 
 
+def _untested(result):
+    """Whether the test could not run, whatever the formatter made of it.
+
+    ``PValueFormat`` reads ``result.pvalue`` in every one of its formats, so
+    that is the value a missing label has to be traced back to.
+    """
+    return np.isnan(result.pvalue)
+
+
 def annotation_texts(brackets, chunks, config):
     """Test every bracket and format the labels, all as one family.
 
@@ -443,9 +452,9 @@ def annotation_texts(brackets, chunks, config):
     texts = [formatter.format_data(result) for result in results]
 
     # An unlabelled bracket is the one failure a reader cannot see on the
-    # figure: too few observations to test formats the same as a p-value the
-    # caller passed as nan, and both look like a finished plot.
-    if blank := [b.original for b, t in zip(brackets, texts) if not t.strip()]:
+    # figure. Ask the result and not the label: `pvalue_thresholds` can map a
+    # real p-value to an empty string on purpose, which is not this.
+    if blank := [b.original for b, r in zip(brackets, results) if _untested(r)]:
         warnings.warn(
             f"{len(blank)} pair(s) produced no p-value and are drawn without a "
             f"label: {sorted(blank, key=str)}",

--- a/src/marsilea/plotter/_stats_annot.py
+++ b/src/marsilea/plotter/_stats_annot.py
@@ -27,6 +27,8 @@ from matplotlib.lines import Line2D
 from matplotlib.patches import Patch
 from matplotlib.text import Text
 
+from ..utils import find_stack_level
+
 #: Every seaborn plotter marsilea wraps can be annotated.
 SUPPORTED_PLOTS = (
     "barplot",
@@ -245,7 +247,7 @@ def _all_pairs(names, hue_order, ref):
                 f"pairs='all' on {len(names)} categories draws {len(combos)} "
                 "brackets, which is rarely readable. Consider listing the pairs "
                 "you care about.",
-                stacklevel=4,
+                stacklevel=find_stack_level(),
             )
     else:
         ref_pos = lookup.get(ref)
@@ -414,7 +416,10 @@ def annotation_texts(brackets, chunks, config):
         keep = frame["var"] == end.position
         if end.hue is not None:
             keep &= frame["hue"] == end.hue
-        return frame.loc[keep, "value"].to_numpy()
+        # Wide input pads its short columns with NaN. Seaborn already draws a
+        # padded slot as absent; a test given one returns pval=nan, which
+        # formats as an empty label on a bracket that is drawn regardless.
+        return frame.loc[keep, "value"].dropna().to_numpy()
 
     if config.pvalues is None:
         test = StatTest.from_library(config.test)
@@ -435,7 +440,18 @@ def annotation_texts(brackets, chunks, config):
 
     formatter = PValueFormat()
     formatter.config(**{k: v for k, v in options.items() if k in formattable})
-    return [formatter.format_data(result) for result in results]
+    texts = [formatter.format_data(result) for result in results]
+
+    # An unlabelled bracket is the one failure a reader cannot see on the
+    # figure: too few observations to test formats the same as a p-value the
+    # caller passed as nan, and both look like a finished plot.
+    if blank := [b.original for b, t in zip(brackets, texts) if not t.strip()]:
+        warnings.warn(
+            f"{len(blank)} pair(s) produced no p-value and are drawn without a "
+            f"label: {sorted(blank, key=str)}",
+            stacklevel=find_stack_level(),
+        )
+    return texts
 
 
 # --- measuring what was actually drawn -------------------------------------
@@ -780,7 +796,7 @@ def annotate(fig, axes, chunks, brackets, config, layout, orient, plot):
             f"{max(tiers) + 1} rows of brackets do not fit above the plot; "
             "the labels will be tight. Give the plot more room, or compare "
             "fewer pairs.",
-            stacklevel=5,
+            stacklevel=find_stack_level(),
         )
 
     # Make room before drawing: the transforms below need the final limits.

--- a/src/marsilea/plotter/mesh.py
+++ b/src/marsilea/plotter/mesh.py
@@ -20,7 +20,13 @@ from ._utils import _format_label
 from .base import RenderPlan
 from .._normalize import densify
 from ..layout import close_ticks
-from ..utils import relative_luminance, get_colormap, ECHARTS16, get_canvas_size_by_data
+from ..utils import (
+    ECHARTS16,
+    find_stack_level,
+    get_canvas_size_by_data,
+    get_colormap,
+    relative_luminance,
+)
 
 
 def _categorical_order(data):
@@ -266,7 +272,8 @@ def _enough_colors(n_colors, n_cats):
         warnings.warn(
             f"Current colormap has only {n_colors} colors "
             f"which is less that your input "
-            f"with {n_cats} elements"
+            f"with {n_cats} elements",
+            stacklevel=find_stack_level(),
         )
 
 

--- a/src/marsilea/plotter/text.py
+++ b/src/marsilea/plotter/text.py
@@ -16,7 +16,7 @@ from matplotlib.text import Text
 from typing import List, Iterable
 
 from .base import RenderPlan
-from ..utils import pairwise, relative_luminance
+from ..utils import find_stack_level, pairwise, relative_luminance
 
 
 class Segment:
@@ -113,7 +113,10 @@ def adjust_segments(lim: Segment, segments: List[Segment]):
     segments_length = np.sum(sl)
     space = lim.length
     if segments_length > space:
-        warnings.warn("No enough space to place all labels, try reducing the fontsize.")
+        warnings.warn(
+            "No enough space to place all labels, try reducing the fontsize.",
+            stacklevel=find_stack_level(),
+        )
 
     segments_length_r = segments_length
     space_r = space

--- a/src/marsilea/utils.py
+++ b/src/marsilea/utils.py
@@ -128,6 +128,17 @@ def _check_side(side):
         raise ValueError(f"`side` must be one of {options}.")
 
 
+def _inside_marsilea(filename):
+    """Whether a frame's file is marsilea's own code.
+
+    Compared at the directory boundary rather than as a string prefix: a
+    sibling package such as ``marsilea_extra`` starts with the same path
+    without being any of ours, and treating it as ours would walk straight
+    past the caller.
+    """
+    return filename.startswith(_PKG_DIR + os.sep)
+
+
 def _notebook_location(filename, lineno):
     """``Cell In[3]:12`` or ``marimo cell Hbol:12``, or None for a real file.
 
@@ -165,7 +176,7 @@ def caller_location():
     frame = sys._getframe(1)
     while frame is not None:
         filename = frame.f_code.co_filename
-        if not filename.startswith(_PKG_DIR):
+        if not _inside_marsilea(filename):
             lineno = frame.f_lineno
             return _notebook_location(filename, lineno) or f"{filename}:{lineno}"
         frame = frame.f_back
@@ -181,7 +192,7 @@ def find_stack_level():
     """
     frame = sys._getframe(1)  # the warnings.warn() call site
     level = 1
-    while frame is not None and frame.f_code.co_filename.startswith(_PKG_DIR):
+    while frame is not None and _inside_marsilea(frame.f_code.co_filename):
         frame = frame.f_back
         level += 1
     return level

--- a/src/marsilea/utils.py
+++ b/src/marsilea/utils.py
@@ -170,3 +170,18 @@ def caller_location():
             return _notebook_location(filename, lineno) or f"{filename}:{lineno}"
         frame = frame.f_back
     return None
+
+
+def find_stack_level():
+    """The ``stacklevel`` that makes a warning point at the caller's own line.
+
+    Counting frames by hand only holds until something between the warning and
+    the user grows a layer, and then the warning quietly blames marsilea. Walk
+    out of the package instead and let the number follow the code.
+    """
+    frame = sys._getframe(1)  # the warnings.warn() call site
+    level = 1
+    while frame is not None and frame.f_code.co_filename.startswith(_PKG_DIR):
+        frame = frame.f_back
+        level += 1
+    return level

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -7,6 +7,7 @@ can be caught at the ``add_*`` call are caught there, and everything else keeps
 its own error and gains a pointer back to where the plotter came from.
 """
 
+import os
 import re
 import sys
 
@@ -16,7 +17,13 @@ import pytest
 import marsilea as ma
 import marsilea.plotter as mp
 from marsilea._deform import Deformation
-from marsilea.utils import caller_location, find_stack_level, _notebook_location
+from marsilea.utils import (
+    _PKG_DIR,
+    _inside_marsilea,
+    _notebook_location,
+    caller_location,
+    find_stack_level,
+)
 
 
 @pytest.fixture
@@ -308,6 +315,12 @@ def test_caller_location_reports_this_file_outside_a_notebook():
 
 def test_find_stack_level_stops_as_soon_as_it_leaves_marsilea():
     assert find_stack_level() == 1
+
+
+def test_a_sibling_package_is_not_marsilea():
+    """`marsilea_extra/plug.py` shares the path without being inside it."""
+    assert _inside_marsilea(os.path.join(_PKG_DIR, "base.py"))
+    assert not _inside_marsilea(_PKG_DIR + "_extra" + os.sep + "plug.py")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -15,7 +15,8 @@ import pytest
 
 import marsilea as ma
 import marsilea.plotter as mp
-from marsilea.utils import caller_location, _notebook_location
+from marsilea._deform import Deformation
+from marsilea.utils import caller_location, find_stack_level, _notebook_location
 
 
 @pytest.fixture
@@ -303,6 +304,26 @@ def test_marimo_running_a_notebook_file_keeps_the_path(monkeypatch):
 def test_caller_location_reports_this_file_outside_a_notebook():
     location = caller_location()
     assert location.startswith(__file__)
+
+
+def test_find_stack_level_stops_as_soon_as_it_leaves_marsilea():
+    assert find_stack_level() == 1
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        # Two frames deep: the decorator that took the keyword.
+        lambda: ma.Heatmap(np.zeros((3, 3)), obs_axis="col"),
+        # Three: a deprecated shim delegating to the one that warns.
+        lambda: Deformation(np.zeros((3, 3))).split_by_row(np.zeros((3, 3))),
+    ],
+)
+def test_a_warning_blames_the_line_that_asked_for_it(call):
+    """However deep marsilea goes to raise it, the warning is about this file."""
+    with pytest.warns((UserWarning, DeprecationWarning)) as caught:
+        call()
+    assert caught[0].filename == __file__
 
 
 def test_ipython_still_offers_the_api_the_cell_name_relies_on():

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -52,6 +52,35 @@ def test_board_binds_source_by_keyword(adata):
     assert h._cluster_data.shape == (N_OBS, N_VARS)
 
 
+@pytest.mark.parametrize(
+    "make",
+    [
+        lambda adata: ma.ZeroWidth(adata, 2),
+        lambda adata: ma.ZeroHeight(adata, 2),
+        lambda adata: ma.ZeroWidthCluster(adata, A.X[:, :], 2),
+        lambda adata: ma.ZeroHeightCluster(adata, A.X[:, :], 2),
+    ],
+    ids=["ZeroWidth", "ZeroHeight", "ZeroWidthCluster", "ZeroHeightCluster"],
+)
+def test_a_zero_board_binds_a_source_like_any_other(make, adata):
+    """Undecorated, these took the source as their size argument instead."""
+    assert make(adata)._source is adata
+
+
+def test_a_zero_cluster_board_takes_a_ref_as_its_cluster_data(adata):
+    board = ma.ZeroWidthCluster(A.X[:, :], height=2, source=adata)
+    assert board._cluster_data.shape == (N_OBS, N_VARS)
+
+
+def test_a_zero_board_resolves_refs_on_its_side_plots(adata):
+    board = ma.ZeroWidth(adata, 2)
+    board.add_left(mp.Numbers(A.obs["score"]), name="bars")
+    board.add_right(mp.Labels(A.obs.index), name="names")
+    board.render()
+    assert len(board.get_ax("bars").patches) == N_OBS
+    assert [t.get_text() for t in board.get_ax("names").texts] == list(adata.obs_names)
+
+
 def test_gene_panel_stacks_into_a_matrix(adata):
     h = ma.Heatmap(adata, A.X[:, ["A", "C"]])
     assert h._cluster_data.shape == (N_OBS, 2)

--- a/tests/test_stats_annotation.py
+++ b/tests/test_stats_annotation.py
@@ -496,6 +496,20 @@ def test_a_group_with_nothing_in_it_is_reported():
     assert len(_brackets(board)) == 2
 
 
+def test_a_label_left_blank_on_purpose_is_not_a_missing_p_value():
+    """`pvalue_thresholds` can map a real p-value to no label at all."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        board, _, _ = _board(
+            "hue",
+            n_cat=2,
+            # Nothing to tell apart, so every p-value lands in the blank bucket.
+            transform=lambda data: {**data, "KO": data["WT"]},
+            pvalue_thresholds=[[1e-4, "****"], [1, ""]],
+        )
+    assert [label.get_text() for label in _labels(board)] == ["", ""]
+
+
 def test_ordinary_data_reports_nothing():
     with warnings.catch_warnings():
         warnings.simplefilter("error", UserWarning)

--- a/tests/test_stats_annotation.py
+++ b/tests/test_stats_annotation.py
@@ -215,6 +215,7 @@ def _board(
     n_cat=6,
     cuts=None,
     plot_kws=None,
+    transform=None,
     **stats_kws,
 ):
     """A canvas with one annotated plot, optionally split into groups."""
@@ -224,6 +225,9 @@ def _board(
         k: pd.DataFrame(rng.normal(shift, 1, (30, n_cat)), columns=cols)
         for k, shift in [("WT", 0), ("KO", 2)]
     }
+    if transform is not None:
+        # Reshape after drawing, so every board sees the same random numbers.
+        data = transform(data)
     kws = dict(plot_kws or {})
     if Plot in NEEDS_DODGE:
         kws.setdefault("dodge", True)
@@ -448,6 +452,55 @@ def test_pairs_naming_an_unknown_category_warn():
     with pytest.warns(UserWarning, match="not in the data"):
         board, _, _ = _board([(("c0", "WT"), ("nope", "KO"))], n_cat=6, cuts=(3,))
     assert len(_brackets(board)) == 0
+
+
+def _blank(condition, column, keep):
+    """Keep the first *keep* observations of one group, NaN the rest.
+
+    Unequal group sizes reach a wide plotter this way: the short columns are
+    padded so the frame stays rectangular.
+    """
+
+    def transform(data):
+        frame = data[condition].copy()
+        frame.loc[keep:, column] = np.nan
+        return {**data, condition: frame}
+
+    return transform
+
+
+def _truncate(condition, keep):
+    """The same group sizes without the padding, as a reference."""
+
+    def transform(data):
+        return {**data, condition: data[condition].iloc[:keep]}
+
+    return transform
+
+
+def test_padding_is_not_an_observation():
+    """A NaN-padded slot must not reach the test, which would return nan."""
+    padded, _, _ = _board("hue", n_cat=2, transform=_blank("WT", "c0", 10))
+    short, _, _ = _board("hue", n_cat=2, transform=_truncate("WT", 10))
+    label = _labels(padded)[0].get_text()
+    assert label.strip()
+    assert label == _labels(short)[0].get_text()
+
+
+def test_a_group_with_nothing_in_it_is_reported():
+    """Blank labels are the one failure a reader cannot see on the figure."""
+    with pytest.warns(UserWarning, match="no p-value"):
+        board, _, _ = _board("hue", n_cat=2, transform=_blank("WT", "c0", 0))
+    assert not _labels(board)[0].get_text().strip()
+    # The bracket is still drawn; only its label is missing.
+    assert len(_brackets(board)) == 2
+
+
+def test_ordinary_data_reports_nothing():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        board, _, _ = _board("hue", n_cat=2)
+    assert all(label.get_text().strip() for label in _labels(board))
 
 
 # --- what seaborn actually drew ---


### PR DESCRIPTION
Three things that looked fine and said nothing. Each one is small; the first is the one that can put a wrong figure in a paper.

## 1. `annotate_stats` drew unlabelled brackets over NaN padding

Wide input has to be rectangular. Group sizes in single-cell data are never equal, so the short columns get padded with `NaN`. Seaborn already treats a padded slot as absent, but `observations()` handed the padding straight to the test:

```python
return frame.loc[keep, "value"].to_numpy()
```

scipy returns `pval=nan`, `PValueFormat.format_data` renders `""`, and [`draw_brackets`](https://github.com/Marsilea-viz/marsilea/blob/main/src/marsilea/plotter/_stats_annot.py#L685) draws the bracket regardless. The result is a figure that looks finished and says nothing, with no warning at any step.

Measured in a fresh env before the fix:

```
nan-padded -> pval nan | label ''
clean n=2  -> pval 0.1588 | label 'ns'
```

The padding never belonged in the test, so it is dropped there:

```python
return frame.loc[keep, "value"].dropna().to_numpy()
```

`.dropna()` rather than `values[~np.isnan(values)]`: no new import, and it does not raise `TypeError` if `pdata["value"]` ever lands on object dtype.

A group can still end up with nothing to test, and an empty label is the one failure a reader cannot see, so `annotation_texts` now says so:

```
UserWarning: 1 pair(s) produced no p-value and are drawn without a label: [(('a', 'WT'), ('a', 'KO'))]
```

The bracket keeps being drawn. `pvalue_thresholds` can be configured with a deliberately empty label, and dropping the bracket would remove one the caller asked for.

### Why padding, and not a ragged input path

Padding is not a workaround here, it is the correct representation, and I checked both halves of that claim.

Seaborn already agrees. Across all seven supported plotters, a padded column and an unpadded one produce identical artist extents:

```
barplot identical   boxplot identical   violinplot identical   stripplot identical
pointplot identical boxenplot identical swarmplot identical
```

And there is no unambiguous way to spell ragged input in the current API. `np.asarray([[1, 2, 3], [4, 5, 6]])` reads the outer list as **rows**, so auto-padding a ragged outer list as **columns** would silently flip orientation between the equal-length and unequal-length cases. A `dict` already means hue levels. The wide-format contract constrains columns only, because that is what has to match the main data for split and reorder; rows are free. Pandas already emits exactly the right thing and keeps the column labels the pairs are named with:

```python
pd.DataFrame({"A": pd.Series(a), "B": pd.Series(b)})
```

So this is documented in the plotter docstrings and the tutorial, and no input code changed.

## 2. Every warning blamed marsilea instead of the caller

Nine warnings carried a hand-counted `stacklevel`; two carried none. All eleven pointed at marsilea's own internals. Measured: the four in the annotation path all resolved to `base.py:1610`, whatever constant they used, because the constants were counted for a chain that has since grown layers.

Counting frames by hand cannot survive a refactor, so `find_stack_level()` walks out of the package instead. It sits next to [`caller_location()`](https://github.com/Marsilea-viz/marsilea/blob/main/src/marsilea/utils.py#L158), which already walks the same stack against the same `_PKG_DIR`, and it uses `sys._getframe` for the same reason that one does:

```python
def find_stack_level():
    frame = sys._getframe(1)  # the warnings.warn() call site
    level = 1
    while frame is not None and frame.f_code.co_filename.startswith(_PKG_DIR):
        frame = frame.f_back
        level += 1
    return level
```

All eleven call sites use it now, the two bare ones included. Verified end to end, at depths from two frames to seven:

```
OK  blank label          -> where.py:24   1 pair(s) produced no p-value ...
OK  undodged             -> where.py:30   2 pair(s) compare hue levels ...
OK  unknown pair         -> where.py:36   1 pair(s) name a category ...
OK  obs_axis no source   -> where.py:47   obs_axis has no effect without ...
OK  pairs='all' dense    -> where3.py:23  pairs='all' on 9 categories ...
OK  crowded brackets     -> where3.py:23  20 rows of brackets do not fit ...
OK  deform deprecation   -> where3.py:26  Deformation.reorder_row is ...
OK  dense sparse         -> where3.py:29  Converting a sparse (30000, 30000) ...
```

`src/oncoprinter/core.py` is left alone: it is a separate top-level package, so a walk keyed on marsilea's directory would stop at its own `warn` line and gain nothing.

## 3. The Zero* boards could not take a data source

`ZeroWidth`, `ZeroHeight`, `ZeroWidthCluster` and `ZeroHeightCluster` each override `__init__` and none of them carried `@accepts_source`, so all three ways in were broken and the first was silent:

```
before                                     after
ZeroHeight(adata, 2)          -> adata bound to `width`, no source   -> source bound
ZeroHeight(2, source=adata)   -> TypeError: unexpected keyword       -> source bound
ZeroWidthCluster(adata, A.X[:, :], 2)
                              -> ValueError from inside numpy        -> reference resolved
```

The decorator is all that was missing. References on their side plots resolve through the board now, the same as any other board:

```python
board = ma.ZeroWidth(adata, 3)
board.add_left(mp.Numbers(A.obs["score"]))
board.add_right(mp.Labels(A.obs.index))
board.render()
```

This is also why #2 had to land with it rather than after. The `obs_axis` warning inside `accepts_source` was `stacklevel=2`, which only held while no decorated `__init__` nested inside another. Decorating the Zero* boards makes them nest, and the walk is what keeps that warning pointing at the caller.

## Tests

Nine new, `718 passed, 6 xfailed`, ruff clean.

- **Padding is not an observation.** A column padded to twice its length annotates the same as the unpadded one. Failed before the fix with `''` against `'****'`.
- **A group with nothing in it is reported**, and its bracket is still drawn.
- **Ordinary data reports nothing**, so the new warning cannot start firing on clean input. Uses the `simplefilter("error", UserWarning)` pattern already in this file.
- **A warning blames the line that asked for it**, parametrized over a two-frame chain and a three-frame one. I checked this is not vacuous: putting `stacklevel=2` back into `_deform.py` (right for the shallow case) fails the deep one.
- **`find_stack_level` stops as soon as it leaves marsilea**, called straight from the test file.
- **Each Zero\* board binds a source**, a `ZeroWidthCluster` takes a reference as its `cluster_data`, and a `ZeroWidth` resolves references on its side plots through to rendered artists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
